### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To run Sirius clone this repository and invoke the containers with `docker-compo
 ```
 git clone https://github.com/SiriusScan/Sirius.git
 cd Sirius
-docker-compose up
+docker compose up
 ```
 
 ### Logging in


### PR DESCRIPTION
Quick pull request to update the README.  `docker-compose up` is the correct syntax for v1, but v1 isn't updated anymore.  For v2 it's `docker compose up` (no dash).