### PR TITLE
fix(monitor): proxy browser requests when frontend calls protected Go…

### DIFF
--- a/sirius-ui/src/components/DockerLogsViewer.tsx
+++ b/sirius-ui/src/components/DockerLogsViewer.tsx
@@ -159,9 +159,7 @@ export const DockerLogsViewer: React.FC<DockerLogsViewerProps> = ({
 
       // Fetch real Docker logs from API
       const response = await fetch(
-        `${
-          process.env.NEXT_PUBLIC_SIRIUS_API_URL || "http://localhost:9001"
-        }/api/v1/system/logs?${params.toString()}`
+        `/api/monitor/proxy/api/v1/system/logs?${params.toString()}`
       );
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/sirius-ui/src/components/PerformanceDashboard.tsx
+++ b/sirius-ui/src/components/PerformanceDashboard.tsx
@@ -213,9 +213,7 @@ export const PerformanceDashboard: React.FC<PerformanceDashboardProps> = ({
 
       // Fetch real performance data from API
       const response = await fetch(
-        `${
-          process.env.NEXT_PUBLIC_SIRIUS_API_URL || "http://localhost:9001"
-        }/api/v1/performance/metrics`
+        "/api/monitor/proxy/api/v1/performance/metrics"
       );
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/sirius-ui/src/components/SystemResourcesDashboard.tsx
+++ b/sirius-ui/src/components/SystemResourcesDashboard.tsx
@@ -229,11 +229,7 @@ export const SystemResourcesDashboard: React.FC<SystemResourceProps> = ({
       setError(null);
 
       // Fetch real system resource data from API
-      const response = await fetch(
-        `${
-          process.env.NEXT_PUBLIC_SIRIUS_API_URL || "http://localhost:9001"
-        }/api/v1/system/resources`
-      );
+      const response = await fetch("/api/monitor/proxy/api/v1/system/resources");
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -303,9 +299,7 @@ export const SystemResourcesDashboard: React.FC<SystemResourceProps> = ({
   const loadContainerLogs = async (containerName: string) => {
     try {
       const response = await fetch(
-        `${
-          process.env.NEXT_PUBLIC_SIRIUS_API_URL || "http://localhost:9001"
-        }/api/v1/system/logs?container=${containerName}&lines=3`
+        `/api/monitor/proxy/api/v1/system/logs?container=${containerName}&lines=3`
       );
       if (response.ok) {
         const data = await response.json();
@@ -656,10 +650,7 @@ export const SystemResourcesDashboard: React.FC<SystemResourceProps> = ({
                                   );
 
                                   const response = await fetch(
-                                    `${
-                                      process.env.NEXT_PUBLIC_SIRIUS_API_URL ||
-                                      "http://localhost:9001"
-                                    }/api/v1/admin/command`,
+                                    "/api/monitor/proxy/api/v1/admin/command",
                                     {
                                       method: "POST",
                                       headers: {

--- a/sirius-ui/src/components/dashboard/SystemHealthMiniWidget.tsx
+++ b/sirius-ui/src/components/dashboard/SystemHealthMiniWidget.tsx
@@ -33,11 +33,7 @@ export const SystemHealthMiniWidget: React.FC<SystemHealthMiniWidgetProps> = ({
   const loadSystemResources = useCallback(async () => {
     try {
       setError(null);
-      const response = await fetch(
-        `${
-          process.env.NEXT_PUBLIC_SIRIUS_API_URL || "http://localhost:9001"
-        }/api/v1/system/resources`
-      );
+      const response = await fetch("/api/monitor/proxy/api/v1/system/resources");
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/sirius-ui/src/hooks/useDashboardData.ts
+++ b/sirius-ui/src/hooks/useDashboardData.ts
@@ -124,11 +124,7 @@ export const useDashboardData = (
 
     try {
       setSystemMetricsLoading(true);
-      const response = await fetch(
-        `${
-          process.env.NEXT_PUBLIC_SIRIUS_API_URL || "http://localhost:9001"
-        }/api/v1/system/resources`
-      );
+      const response = await fetch("/api/monitor/proxy/api/v1/system/resources");
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/sirius-ui/src/pages/api/monitor/proxy/[...path].ts
+++ b/sirius-ui/src/pages/api/monitor/proxy/[...path].ts
@@ -1,0 +1,81 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { env } from "~/env.mjs";
+import { getServerAuthSession } from "~/server/auth";
+
+const ALLOWED_PREFIXES = [
+  "/api/v1/system/",
+  "/api/v1/logs",
+  "/api/v1/admin/command",
+  "/api/v1/performance/metrics",
+];
+
+function isAllowedPath(pathname: string): boolean {
+  return ALLOWED_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const session = await getServerAuthSession({ req, res });
+  if (!session?.user) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const segments = req.query.path;
+  const pathSegments = Array.isArray(segments) ? segments : [];
+  const pathname = `/${pathSegments.join("/")}`;
+
+  if (!isAllowedPath(pathname)) {
+    return res.status(403).json({ error: "Forbidden path" });
+  }
+
+  const upstreamBase = env.SIRIUS_API_URL || "http://sirius-api:9001";
+  const query = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(req.query)) {
+    if (key === "path") continue;
+    if (Array.isArray(value)) {
+      for (const v of value) query.append(key, v);
+    } else if (typeof value === "string") {
+      query.append(key, value);
+    }
+  }
+
+  const upstreamUrl =
+    query.toString().length > 0
+      ? `${upstreamBase}${pathname}?${query.toString()}`
+      : `${upstreamBase}${pathname}`;
+
+  const headers: Record<string, string> = {
+    "X-API-Key": env.SIRIUS_API_KEY,
+  };
+
+  if (req.headers["content-type"]) {
+    headers["Content-Type"] = req.headers["content-type"];
+  } else {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const method = req.method || "GET";
+  const hasBody = !["GET", "HEAD"].includes(method.toUpperCase());
+
+  try {
+    const upstreamResponse = await fetch(upstreamUrl, {
+      method,
+      headers,
+      body: hasBody ? JSON.stringify(req.body ?? {}) : undefined,
+    });
+
+    const responseText = await upstreamResponse.text();
+    const contentType = upstreamResponse.headers.get("content-type");
+    if (contentType) {
+      res.setHeader("Content-Type", contentType);
+    }
+
+    return res.status(upstreamResponse.status).send(responseText);
+  } catch (error) {
+    console.error("Monitor proxy request failed:", error);
+    return res.status(502).json({ error: "Upstream monitor API unavailable" });
+  }
+}

--- a/sirius-ui/src/pages/system-monitor.tsx
+++ b/sirius-ui/src/pages/system-monitor.tsx
@@ -198,11 +198,7 @@ const SystemMonitor: NextPage = () => {
   const loadResourceData = async () => {
     try {
       setResourceLoading(true);
-      const response = await fetch(
-        `${
-          process.env.NEXT_PUBLIC_SIRIUS_API_URL || "http://localhost:9001"
-        }/api/v1/system/resources`,
-      );
+      const response = await fetch("/api/monitor/proxy/api/v1/system/resources");
       if (response.ok) {
         const data = await response.json();
         setResourceData(data);

--- a/sirius-ui/src/services/healthCheckService.ts
+++ b/sirius-ui/src/services/healthCheckService.ts
@@ -30,8 +30,7 @@ class HealthCheckService {
   };
 
   constructor(
-    baseUrl: string = process.env.NEXT_PUBLIC_SIRIUS_API_URL ||
-      "http://localhost:9001"
+    baseUrl: string = "/api/monitor/proxy"
   ) {
     this.baseUrl = baseUrl;
   }

--- a/sirius-ui/src/services/logService.ts
+++ b/sirius-ui/src/services/logService.ts
@@ -54,10 +54,7 @@ export class LogService {
   private retries: number;
 
   constructor(options: LogServiceOptions = {}) {
-    this.baseUrl =
-      options.baseUrl ||
-      process.env.NEXT_PUBLIC_SIRIUS_API_URL ||
-      "http://localhost:9001";
+    this.baseUrl = options.baseUrl || "/api/monitor/proxy";
     this.timeout = options.timeout || 10000;
     this.retries = options.retries || 3;
   }


### PR DESCRIPTION
… API directly

Condition: applies whenever the browser hits protected /api/v1/system|/logs|/admin|/performance endpoints directly without X-API-Key (localhost or hosted domain).

Route monitor traffic through a server-side Next.js proxy that injects X-API-Key and enforces allowed paths/session auth.

## Summary

Without this the installation commands from the README.md instantiates a local setup where the frontend can't talk to the backend. This just transparently injects the key for authenticated sessions so the frontend doesn't need to have it in memory. 

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] CI/CD or automation
- [ ] Security hardening

## Scope

- [x] `sirius-ui`
- [ ] `sirius-api`
- [ ] `sirius-engine`
- [ ] Infrastructure (`postgres`, `rabbitmq`, `valkey`, compose)
- [ ] Documentation
- [ ] Other (describe below)

## Related Issue

Closes #

## Validation

- [x] I ran required local validation for this change
- [ ] I attached logs, screenshots, or output where relevant
- [ ] I tested failure paths or edge cases where applicable
- [x] CI checks are expected to pass for this PR

  Validation output attached/referenced:

  - Unauthenticated request to protected endpoint returns 401:
      - GET /api/v1/system/health -> {"error":"missing API key – include X-API-Key header"}
  - Authenticated request returns 200:
      - GET /api/v1/system/health with X-API-Key -> healthy payload
  - Runtime env parity confirmed across sirius-ui, sirius-api, sirius-engine for SIRIUS_API_KEY (no key drift)
  - Proxy route added and monitor UI fetch paths updated to /api/monitor/proxy/...

  ## Security and Risk Review

  - [ ] No security impact
  - [x] Security impact reviewed and documented
  - [x] Rollback steps are documented for risky operational changes

  Security notes:

  - Added server-side monitor proxy that injects X-API-Key from server env.
  - Proxy enforces session auth (401 when no session).
  - Proxy restricts upstream access to allowlisted monitor paths only (403 for disallowed paths).

  Rollback steps:

  1. Revert commit e764fcd4.
  2. Rebuild/redeploy sirius-ui.
  3. Confirm monitor requests no longer use /api/monitor/proxy/*.

  ## Documentation

  - [x] No docs change needed
  - [ ] Updated README.md, CONTRIBUTING.md, SECURITY.md, or related docs
  - [ ] Added/updated issue templates or workflow docs

  ## Deployment Notes

  - Requires sirius-ui rebuild/redeploy from source for changes to take effect.
  - No secret schema change; existing SIRIUS_API_KEY is reused server-side.
  - No DB migrations.
  - Operationally important: this fix applies when browser code would otherwise call protected Go API endpoints directly (localhost or hosted domain). Domain hosting alone does not bypass API-key requirements.
  - If deploy tooling reads .env, ensure it is readable by the deploy user (we hit open .../.env: permission denied during local restart attempt).

  ## Additional Context

  - Root cause was browser-direct requests to protected /api/v1/system|logs|admin|performance endpoints, which cannot safely carry server secret SIRIUS_API_KEY.
  - This change routes those requests through Next.js server code, preserving auth boundary and fixing monitor 401 errors.
  - Known limitation: monitor proxy endpoints require a valid app session.

