### PR TITLE
fix(build): resolve Windows CRLF build failure (closes #109)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.go]
+indent_style = tab
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Force LF for all text files -- prevents CRLF from entering containers
+* text=auto eol=lf
+
+# Explicitly mark binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,19 @@ docker compose up -d
 
 For advanced local development, follow [`documentation/contributing.md`](./documentation/contributing.md).
 
+### Windows Development
+
+Sirius targets Linux containers. On Windows only **Docker Desktop** is required to clone, build, and run the full stack via `docker compose`.
+
+- The repository ships a `.gitattributes` that forces LF line endings on all platforms. If you cloned before this file existed and see `\r\n` issues, re-normalise your checkout:
+
+```bash
+git add --renormalize .
+git checkout -- .
+```
+
+- Avoid setting `core.autocrlf = true` in your Git config; the `.gitattributes` file handles line endings automatically.
+
 ## Branch and Commit Standards
 
 - Branch naming: `<type>/<short-description>` (example: `fix/auth-key-drift`)

--- a/sirius-api/Dockerfile
+++ b/sirius-api/Dockerfile
@@ -21,7 +21,7 @@ RUN chown -R appuser:appgroup /api
 
 # Copy startup script
 COPY start-dev.sh /start-dev.sh
-RUN chmod +x /start-dev.sh
+RUN sed -i 's/\r$//' /start-dev.sh && chmod +x /start-dev.sh
 
 # Switch to non-root user
 USER appuser

--- a/sirius-postgres/Dockerfile
+++ b/sirius-postgres/Dockerfile
@@ -76,7 +76,8 @@ CONTAINER_NAME=sirius-postgres /usr/local/bin/system-monitor >> /tmp/system-moni
 echo "✅ All services started"
 wait "$POSTGRES_PID"
 EOF
-RUN chmod +x /usr/local/bin/start-with-monitor.sh
+RUN sed -i 's/\r$//' /usr/local/bin/start-with-monitor.sh && \
+    chmod +x /usr/local/bin/start-with-monitor.sh
 RUN test -x /usr/local/bin/start-with-monitor.sh && /bin/sh -n /usr/local/bin/start-with-monitor.sh
 
 # Set environment variables for system monitor

--- a/sirius-ui/Dockerfile
+++ b/sirius-ui/Dockerfile
@@ -61,7 +61,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 
 # Copy startup script
 COPY start-dev.sh /app/start-dev.sh
-RUN chmod +x /app/start-dev.sh
+RUN sed -i 's/\r$//' /app/start-dev.sh && chmod +x /app/start-dev.sh
 
 # Create non-root user for development
 RUN addgroup --system --gid 1001 nodejs && \
@@ -160,7 +160,7 @@ COPY --from=builder /app/next.config.mjs ./next.config.mjs
 
 # Copy production startup script
 COPY start-prod.sh /app/start-prod.sh
-RUN chmod +x /app/start-prod.sh
+RUN sed -i 's/\r$//' /app/start-prod.sh && chmod +x /app/start-prod.sh
 
 # Change ownership
 RUN chown -R nextjs:nodejs /app /system-monitor


### PR DESCRIPTION
## Summary

- Add `.gitattributes` to enforce LF line endings repo-wide, preventing Windows `core.autocrlf` from injecting CRLF into files that end up inside Linux containers.
- Add `sed -i 's/\r$//'` CRLF stripping in `sirius-postgres/Dockerfile` (the reported bug), `sirius-ui/Dockerfile`, and `sirius-api/Dockerfile` as a defense-in-depth safety net for any shell scripts COPY'd into containers.
- Add `.editorconfig` for consistent cross-platform editor settings (LF, UTF-8, indentation).
- Document Windows prerequisites in `CONTRIBUTING.md` -- only Docker Desktop is required.

Closes #109

## Test plan

- [x] Pre-commit hook passed all 11 tests including sirius-postgres entrypoint contract validation
- [x] `sirius-postgres` builds successfully with the `sed` CRLF strip and passes `/bin/sh -n` syntax check
- [x] `sirius-ui` production build completes successfully
- [x] All Docker Compose config validations pass (base, dev, prod)
- [ ] Windows contributor verifies clean clone + `docker compose up` workflow

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build- and documentation-only changes that primarily affect line-ending normalization; runtime behavior should be unchanged aside from more robust script execution in containers.
> 
> **Overview**
> Fixes Windows checkouts breaking Linux-container startup scripts by **enforcing LF line endings repo-wide** via new `.gitattributes`, and by adding `.editorconfig` to align editor formatting across platforms.
> 
> Adds **defense-in-depth CRLF stripping** in `sirius-api`, `sirius-ui` (dev + prod), and `sirius-postgres` Dockerfiles by running `sed -i 's/\r$//'` on copied entrypoint/start scripts before `chmod +x`, and documents the Windows Docker Desktop workflow plus renormalization steps in `CONTRIBUTING.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21c30f848e5b9d9c93c29f3afbe4a7861a7b660b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->