### PR TITLE
fix(api): write proper TemplateInfo envelope + meta on custom upload

### DIFF
--- a/sirius-api/handlers/agent_template_handler.go
+++ b/sirius-api/handlers/agent_template_handler.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -12,6 +14,7 @@ import (
 	"github.com/SiriusScan/go-api/sirius/queue"
 	"github.com/SiriusScan/go-api/sirius/store"
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 )
 
@@ -110,7 +113,130 @@ func (t *AgentTemplateYAML) GetVersion() string {
 const (
 	agentTemplateKeyPrefix = "template:"
 	agentTemplateManifest  = "template:manifest"
+	agentTemplateMetaKey   = "template:meta:"
+	agentTemplateSyncQueue = "agent.template.sync.jobs"
 )
+
+// templateInfoRecord mirrors app-agent's
+// internal/template/valkey.TemplateInfo so a record written here can be
+// decoded by the agent-side reader without translation. Keep field names
+// and JSON tags in lock-step with that struct; PR 6 will replace this
+// duplication with a shared go-api package.
+type templateInfoRecord struct {
+	ID               string            `json:"id"`
+	Version          string            `json:"version"`
+	Checksum         string            `json:"checksum"`
+	Size             int64             `json:"size"`
+	Severity         string            `json:"severity"`
+	Platforms        []string          `json:"platforms"`
+	DetectionType    string            `json:"detection_type"`
+	Author           string            `json:"author"`
+	Created          time.Time         `json:"created"`
+	Updated          time.Time         `json:"updated"`
+	VulnerabilityIDs []string          `json:"vulnerability_ids"`
+	IsCustom         bool              `json:"is_custom"`
+	Content          []byte            `json:"content,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
+}
+
+// templateSyncJobMessage mirrors app-agent's server.SyncJobMessage. Used
+// to publish notify_agents requests on agent.template.sync.jobs.
+type templateSyncJobMessage struct {
+	Action      string `json:"action"`
+	TemplateID  string `json:"template_id,omitempty"`
+	TriggeredBy string `json:"triggered_by"`
+	Timestamp   string `json:"timestamp"`
+	JobID       string `json:"job_id"`
+}
+
+// detectionTypeFromYAML extracts the first detection step's "type" field.
+// Mirrors app-agent's getDetectionType helper closely enough that meta
+// records written here look like ones the agent-side sync writer emits.
+func detectionTypeFromYAML(t *AgentTemplateYAML) string {
+	for _, step := range t.Detection.Steps {
+		if v, ok := step["type"].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// platformsFromYAML mirrors the platform extraction used elsewhere in
+// this handler. Returns the first non-empty platforms list it finds in
+// detection steps; defaults to ["linux"] for parity with the read path.
+func platformsFromYAML(t *AgentTemplateYAML) []string {
+	for _, step := range t.Detection.Steps {
+		if p, ok := step["platforms"].([]interface{}); ok && len(p) > 0 {
+			out := make([]string, len(p))
+			for i, v := range p {
+				out[i] = fmt.Sprintf("%v", v)
+			}
+			return out
+		}
+	}
+	return []string{"linux"}
+}
+
+// buildTemplateRecord builds the envelope + meta records (and their JSON
+// bytes) for a custom template upload/update. Returned as a pair so PR 4
+// can reuse this for UpdateAgentTemplate.
+func buildTemplateRecord(yamlTemplate *AgentTemplateYAML, rawYAML []byte, isCustom bool, createdAt time.Time) (envelopeJSON, metaJSON []byte, checksum string, err error) {
+	sum := sha256.Sum256(rawYAML)
+	checksum = hex.EncodeToString(sum[:])
+
+	now := time.Now().UTC()
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+
+	envelope := templateInfoRecord{
+		ID:               yamlTemplate.ID,
+		Version:          yamlTemplate.GetVersion(),
+		Checksum:         checksum,
+		Size:             int64(len(rawYAML)),
+		Severity:         yamlTemplate.GetSeverity(),
+		Platforms:        platformsFromYAML(yamlTemplate),
+		DetectionType:    detectionTypeFromYAML(yamlTemplate),
+		Author:           yamlTemplate.GetAuthor(),
+		Created:          createdAt,
+		Updated:          now,
+		VulnerabilityIDs: nil,
+		IsCustom:         isCustom,
+		Content:          rawYAML,
+		Metadata:         map[string]string{"source": "sirius-api-upload"},
+	}
+
+	envelopeJSON, err = json.Marshal(envelope)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("marshal envelope: %w", err)
+	}
+
+	metaCopy := envelope
+	metaCopy.Content = nil
+	metaJSON, err = json.Marshal(metaCopy)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("marshal meta: %w", err)
+	}
+	return envelopeJSON, metaJSON, checksum, nil
+}
+
+// publishNotifyAgents publishes a notify_agents sync job so connected
+// agents re-pull the template inventory. Best-effort: returns the
+// underlying error but the caller decides whether to fail the request.
+func publishNotifyAgents(templateID, triggeredBy string) error {
+	msg := templateSyncJobMessage{
+		Action:      "notify_agents",
+		TemplateID:  templateID,
+		TriggeredBy: triggeredBy,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		JobID:       uuid.New().String(),
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal sync message: %w", err)
+	}
+	return queue.Send(agentTemplateSyncQueue, string(data))
+}
 
 // GetAgentTemplates returns all agent templates from Valkey
 func GetAgentTemplates(c *fiber.Ctx) error {
@@ -345,15 +471,23 @@ func UploadAgentTemplate(c *fiber.Ctx) error {
 		})
 	}
 
-	// Override author if provided
 	if request.Author != "" {
 		yamlTemplate.Info.Author = request.Author
-		// Re-marshal with updated author
-		updatedYAML, _ := yaml.Marshal(yamlTemplate)
-		request.Content = string(updatedYAML)
+		updatedYAML, mErr := yaml.Marshal(yamlTemplate)
+		if mErr == nil {
+			request.Content = string(updatedYAML)
+		}
+	}
+	rawYAML := []byte(request.Content)
+
+	envelopeJSON, metaJSON, checksum, err := buildTemplateRecord(&yamlTemplate, rawYAML, true, time.Time{})
+	if err != nil {
+		slog.Error("Failed to build template record", "id", yamlTemplate.ID, "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to encode template",
+		})
 	}
 
-	// Store in Valkey
 	kvStore, err := store.NewValkeyStore()
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
@@ -363,24 +497,38 @@ func UploadAgentTemplate(c *fiber.Ctx) error {
 	defer kvStore.Close()
 
 	templateKey := agentTemplateKeyPrefix + "custom:" + yamlTemplate.ID
-	if err := kvStore.SetValue(ctx, templateKey, request.Content); err != nil {
+	metaKey := agentTemplateMetaKey + yamlTemplate.ID
+
+	if err := kvStore.SetValue(ctx, templateKey, string(envelopeJSON)); err != nil {
+		slog.Error("Failed to store template envelope", "id", yamlTemplate.ID, "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to store template",
 		})
 	}
 
-	// Notify engine of new template
-	message := map[string]interface{}{
-		"command":     "internal:template upload",
-		"template_id": yamlTemplate.ID,
-		"timestamp":   time.Now().Format(time.RFC3339),
+	if err := kvStore.SetValue(ctx, metaKey, string(metaJSON)); err != nil {
+		// Roll back envelope so we never leave a custom record without a
+		// matching meta entry (which would render the template invisible
+		// to agent enumeration).
+		if delErr := kvStore.DeleteValue(ctx, templateKey); delErr != nil {
+			slog.Warn("Rollback failed after meta-write error", "id", yamlTemplate.ID, "error", delErr)
+		}
+		slog.Error("Failed to store template meta", "id", yamlTemplate.ID, "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to store template metadata",
+		})
 	}
-	msgBytes, _ := json.Marshal(message)
-	_ = queue.Send("engine.commands", string(msgBytes))
+
+	if err := publishNotifyAgents(yamlTemplate.ID, "sirius-api"); err != nil {
+		// Don't fail the request: the records are persisted and agents
+		// will pick them up on their next periodic sync. Log loudly.
+		slog.Warn("Failed to publish notify_agents", "id", yamlTemplate.ID, "error", err)
+	}
 
 	return c.JSON(fiber.Map{
-		"id":      yamlTemplate.ID,
-		"message": "Template uploaded successfully",
+		"id":       yamlTemplate.ID,
+		"checksum": checksum,
+		"message":  "Template uploaded successfully",
 	})
 }
 

--- a/sirius-api/handlers/agent_template_handler_test.go
+++ b/sirius-api/handlers/agent_template_handler_test.go
@@ -1,0 +1,146 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const fixtureYAML = `id: test-cve-2026-0001
+info:
+  name: Test CVE 2026-0001
+  author: tester
+  severity: high
+  description: Detects a fictional vulnerability used in unit tests.
+  version: 1.0.0
+  tags:
+    - test
+detection:
+  steps:
+    - type: command
+      platforms:
+        - linux
+        - darwin
+      command: "echo vulnerable"
+`
+
+func parseFixture(t *testing.T) *AgentTemplateYAML {
+	t.Helper()
+	var tpl AgentTemplateYAML
+	if err := yaml.Unmarshal([]byte(fixtureYAML), &tpl); err != nil {
+		t.Fatalf("failed to parse fixture YAML: %v", err)
+	}
+	return &tpl
+}
+
+func TestBuildTemplateRecord_EnvelopeShape(t *testing.T) {
+	tpl := parseFixture(t)
+	raw := []byte(fixtureYAML)
+
+	envBytes, metaBytes, checksum, err := buildTemplateRecord(tpl, raw, true, time.Time{})
+	if err != nil {
+		t.Fatalf("buildTemplateRecord returned error: %v", err)
+	}
+	if checksum == "" {
+		t.Fatal("expected non-empty checksum")
+	}
+
+	var envelope templateInfoRecord
+	if err := json.Unmarshal(envBytes, &envelope); err != nil {
+		t.Fatalf("envelope is not valid JSON of templateInfoRecord: %v", err)
+	}
+
+	if envelope.ID != "test-cve-2026-0001" {
+		t.Errorf("envelope ID mismatch: got %q", envelope.ID)
+	}
+	if envelope.Severity != "high" {
+		t.Errorf("envelope Severity mismatch: got %q", envelope.Severity)
+	}
+	if envelope.DetectionType != "command" {
+		t.Errorf("envelope DetectionType mismatch: got %q", envelope.DetectionType)
+	}
+	if !envelope.IsCustom {
+		t.Error("envelope IsCustom should be true for custom uploads")
+	}
+	if envelope.Checksum != checksum {
+		t.Errorf("envelope Checksum %q != returned checksum %q", envelope.Checksum, checksum)
+	}
+	if envelope.Size != int64(len(raw)) {
+		t.Errorf("envelope Size %d != raw len %d", envelope.Size, len(raw))
+	}
+	if string(envelope.Content) != string(raw) {
+		t.Error("envelope Content should round-trip to the original raw YAML bytes")
+	}
+	if got, want := envelope.Platforms, []string{"linux", "darwin"}; !equalStrings(got, want) {
+		t.Errorf("envelope Platforms = %v, want %v", got, want)
+	}
+
+	// JSON wire shape: Content must serialize as base64 string under "content".
+	var raw1 map[string]any
+	if err := json.Unmarshal(envBytes, &raw1); err != nil {
+		t.Fatalf("envelope is not generic JSON: %v", err)
+	}
+	contentStr, ok := raw1["content"].(string)
+	if !ok {
+		t.Fatalf("envelope.content must be a base64 string on the wire; got %T", raw1["content"])
+	}
+	decoded, err := base64.StdEncoding.DecodeString(contentStr)
+	if err != nil {
+		t.Fatalf("envelope.content is not valid base64: %v", err)
+	}
+	if string(decoded) != fixtureYAML {
+		t.Error("base64-decoded content does not match the original raw YAML")
+	}
+
+	// Meta must NOT carry content.
+	var meta templateInfoRecord
+	if err := json.Unmarshal(metaBytes, &meta); err != nil {
+		t.Fatalf("meta is not valid JSON: %v", err)
+	}
+	if len(meta.Content) != 0 {
+		t.Error("meta record must omit Content")
+	}
+	if !meta.IsCustom {
+		t.Error("meta IsCustom should be true for custom uploads")
+	}
+	if meta.ID != envelope.ID || meta.Checksum != envelope.Checksum {
+		t.Error("meta record core identity fields must match envelope")
+	}
+}
+
+func TestBuildTemplateRecord_DetectionTypeFallback(t *testing.T) {
+	const noStepsYAML = `id: empty-detect
+info:
+  name: empty
+  author: t
+  severity: low
+detection: {}
+`
+	var tpl AgentTemplateYAML
+	if err := yaml.Unmarshal([]byte(noStepsYAML), &tpl); err != nil {
+		t.Fatal(err)
+	}
+	envBytes, _, _, err := buildTemplateRecord(&tpl, []byte(noStepsYAML), true, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(envBytes), `"detection_type":""`) {
+		t.Errorf("expected empty detection_type when no steps; got: %s", envBytes)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/tasks/scanner-templates-fix.json
+++ b/tasks/scanner-templates-fix.json
@@ -85,8 +85,8 @@
     "id": "2",
     "title": "PR 2: Agent Template View/Edit Auth Fix",
     "description": "Replace unauthenticated browser fetch in AgentTemplatesTab with tRPC route.",
-    "details": "handleView and handleEdit currently bypass apiFetch and miss the X-API-Key header, returning 401. Switch to api.agentTemplates.getTemplate.fetch (or utils.fetch) and remove NEXT_PUBLIC_SIRIUS_API_URL from this component.",
-    "status": "pending",
+    "details": "handleView and handleEdit currently bypass apiFetch and miss the X-API-Key header, returning 401. Switch to api.agentTemplates.getTemplate.fetch (or utils.fetch) and remove NEXT_PUBLIC_SIRIUS_API_URL from this component. Merged as Sirius#121 (7d96bf5c3) on 2026-04-23.",
+    "status": "done",
     "priority": "high",
     "dependencies": ["1"],
     "subtasks": []


### PR DESCRIPTION
## Summary

PR 3 of the scanner-templates-fix sprint. Fixes Bug 3 from [scanner-templates-fix-plan.md](documentation/dev-notes/scanner-templates-fix-plan.md): newly uploaded custom agent templates were invisible to connected agents and never executed during agent-based scans.

## Root cause (three drift bugs in one handler)

1. **Format mismatch.** ``UploadAgentTemplate`` stored raw YAML at ``template:custom:<id>``. The agent-side reader (``app-agent/internal/template/valkey.GetTemplate``) expects a JSON envelope shaped like ``TemplateInfo`` (``{ id, version, checksum, size, severity, platforms, detection_type, author, ..., is_custom, content, metadata }`` with ``content`` base64-encoded).
2. **Missing meta record.** The handler never wrote ``template:meta:<id>``. Agent enumeration starts at ``template:meta:*``; without a meta entry, the new template is invisible.
3. **Wrong queue.** The handler published ``internal:template upload`` to ``engine.commands``, which has **no consumer** in ``app-agent`` today (PR 5 in this sprint adds a defense-in-depth listener). The notification was silently dropped.

## Change set

``sirius-api/handlers/agent_template_handler.go``:

- New ``templateInfoRecord`` struct whose JSON tags exactly mirror ``app-agent``'s ``TemplateInfo``. PR 6 will retire this duplication via a shared ``go-api`` package.
- New ``buildTemplateRecord`` helper - returns envelope + meta JSON + sha256 checksum. Designed to be reused by PR 4's ``UpdateAgentTemplate``.
- New ``publishNotifyAgents`` helper - publishes a ``notify_agents`` action on ``agent.template.sync.jobs``.
- Rewrote ``UploadAgentTemplate`` to compute checksum, build envelope + meta, write both with rollback on meta failure, and trigger notify_agents.

The companion consumer for ``notify_agents`` ships in [SiriusScan/app-agent#2](https://github.com/SiriusScan/app-agent/pull/2). Until that lands the action is logged + ignored by the existing ``default`` switch arm in ``template_sync_queue.go``, so this PR is functionally safe to land first (templates will still be persisted correctly; notification just won't fire until both PRs are deployed together).

## Tests

- New unit tests in ``sirius-api/handlers/agent_template_handler_test.go``:
  - ``TestBuildTemplateRecord_EnvelopeShape``: round-trips fixture YAML, asserts envelope ID/severity/detection_type/is_custom/checksum/size/platforms, asserts ``content`` serializes as a base64 string on the wire and decodes back to the original YAML, asserts meta omits ``Content``.
  - ``TestBuildTemplateRecord_DetectionTypeFallback``: empty ``detection.steps`` produces empty ``detection_type``.
- ``go test -short ./...`` green across ``sirius-api``.
- Backwards-compatible with the existing read path in ``GetAgentTemplate`` (lines 153-170): the new envelope JSON unmarshals cleanly into the legacy ``AgentTemplateJSON`` struct because the field set is a strict superset and ``content`` (string) <-> ``Content []byte`` both serialize as base64 strings.

## Verification (after merge + image rebuild)

1. Upload a new custom template through the UI.
2. ``docker exec sirius-valkey valkey-cli GET template:custom:<id>`` returns the JSON envelope (``content`` base64-encoded).
3. ``docker exec sirius-valkey valkey-cli GET template:meta:<id>`` returns the meta record with ``is_custom: true`` and no ``content`` field.
4. Engine log shows ``Processing notify_agents request`` followed by ``Notifying connected agents`` (after [SiriusScan/app-agent#2](https://github.com/SiriusScan/app-agent/pull/2) is also deployed).
5. Agent-based scan picks up the new template.

## Out of scope

- Update flow (PR 4).
- engine.commands defense-in-depth consumer (PR 5).
- Replacing the JSON-or-YAML read heuristic (PR 7).
- ``DeleteAgentTemplate`` still publishes to ``engine.commands``; addressed in PR 4 along with the update flow.

## Tracker

Marks PR 2 (#121) done in ``tasks/scanner-templates-fix.json``.

Refs: scanner-templates-fix sprint PR 3.