### PR TITLE
feat(scanner-templates): UpdateAgentTemplate handler + UI wiring (PR 4)

### DIFF
--- a/sirius-api/handlers/agent_template_handler.go
+++ b/sirius-api/handlers/agent_template_handler.go
@@ -220,6 +220,41 @@ func buildTemplateRecord(yamlTemplate *AgentTemplateYAML, rawYAML []byte, isCust
 	return envelopeJSON, metaJSON, checksum, nil
 }
 
+// persistTemplateRecord stores envelope + meta in Valkey with rollback
+// semantics: if the meta write fails the envelope is removed so an
+// agent enumeration never sees a custom template without a matching
+// meta entry. Shared by Upload and Update flows.
+func persistTemplateRecord(ctx context.Context, kvStore store.KVStore, templateID string, envelopeJSON, metaJSON []byte) error {
+	templateKey := agentTemplateKeyPrefix + "custom:" + templateID
+	metaKey := agentTemplateMetaKey + templateID
+
+	if err := kvStore.SetValue(ctx, templateKey, string(envelopeJSON)); err != nil {
+		return fmt.Errorf("write envelope: %w", err)
+	}
+	if err := kvStore.SetValue(ctx, metaKey, string(metaJSON)); err != nil {
+		if delErr := kvStore.DeleteValue(ctx, templateKey); delErr != nil {
+			slog.Warn("Rollback failed after meta-write error", "id", templateID, "error", delErr)
+		}
+		return fmt.Errorf("write meta: %w", err)
+	}
+	return nil
+}
+
+// readExistingMeta returns the previously stored meta record for the
+// given template id (custom-namespace only). Used by Update to decide
+// whether to preserve `IsCustom` and the original `created` timestamp.
+func readExistingMeta(ctx context.Context, kvStore store.KVStore, templateID string) (*templateInfoRecord, error) {
+	resp, err := kvStore.GetValue(ctx, agentTemplateMetaKey+templateID)
+	if err != nil || resp.Message.Value == "" {
+		return nil, err
+	}
+	var meta templateInfoRecord
+	if uErr := json.Unmarshal([]byte(resp.Message.Value), &meta); uErr != nil {
+		return nil, fmt.Errorf("decode meta: %w", uErr)
+	}
+	return &meta, nil
+}
+
 // publishNotifyAgents publishes a notify_agents sync job so connected
 // agents re-pull the template inventory. Best-effort: returns the
 // underlying error but the caller decides whether to fail the request.
@@ -496,26 +531,10 @@ func UploadAgentTemplate(c *fiber.Ctx) error {
 	}
 	defer kvStore.Close()
 
-	templateKey := agentTemplateKeyPrefix + "custom:" + yamlTemplate.ID
-	metaKey := agentTemplateMetaKey + yamlTemplate.ID
-
-	if err := kvStore.SetValue(ctx, templateKey, string(envelopeJSON)); err != nil {
-		slog.Error("Failed to store template envelope", "id", yamlTemplate.ID, "error", err)
+	if err := persistTemplateRecord(ctx, kvStore, yamlTemplate.ID, envelopeJSON, metaJSON); err != nil {
+		slog.Error("Failed to persist template", "id", yamlTemplate.ID, "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to store template",
-		})
-	}
-
-	if err := kvStore.SetValue(ctx, metaKey, string(metaJSON)); err != nil {
-		// Roll back envelope so we never leave a custom record without a
-		// matching meta entry (which would render the template invisible
-		// to agent enumeration).
-		if delErr := kvStore.DeleteValue(ctx, templateKey); delErr != nil {
-			slog.Warn("Rollback failed after meta-write error", "id", yamlTemplate.ID, "error", delErr)
-		}
-		slog.Error("Failed to store template meta", "id", yamlTemplate.ID, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Failed to store template metadata",
 		})
 	}
 
@@ -698,9 +717,104 @@ func TestAgentTemplate(c *fiber.Ctx) error {
 	})
 }
 
-// Placeholder implementations for other endpoints
+// UpdateAgentTemplate replaces an existing custom template's envelope +
+// meta records and triggers an agent re-pull. Built-in (non-custom)
+// templates remain editable for parity with the upload path, but the
+// `is_custom` flag and original `created` timestamp on the existing
+// meta record are preserved so we never silently flip a built-in into
+// a custom one (or vice versa) just because someone hit Save.
 func UpdateAgentTemplate(c *fiber.Ctx) error {
-	return c.JSON(fiber.Map{"message": "Update not yet implemented"})
+	ctx := context.Background()
+	templateID := strings.TrimSpace(c.Params("id"))
+	if templateID == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Template id is required",
+		})
+	}
+
+	type UpdateRequest struct {
+		Content  string `json:"content"`
+		Filename string `json:"filename,omitempty"`
+		Author   string `json:"author,omitempty"`
+	}
+
+	var request UpdateRequest
+	if err := c.BodyParser(&request); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+		})
+	}
+
+	var yamlTemplate AgentTemplateYAML
+	if err := yaml.Unmarshal([]byte(request.Content), &yamlTemplate); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid YAML format",
+		})
+	}
+
+	if yamlTemplate.ID == "" || yamlTemplate.GetName() == "" || yamlTemplate.GetSeverity() == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Template missing required fields (id, info.name, info.severity)",
+		})
+	}
+
+	if yamlTemplate.ID != templateID {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("URL id %q does not match YAML id %q", templateID, yamlTemplate.ID),
+		})
+	}
+
+	if request.Author != "" {
+		yamlTemplate.Info.Author = request.Author
+		updatedYAML, mErr := yaml.Marshal(yamlTemplate)
+		if mErr == nil {
+			request.Content = string(updatedYAML)
+		}
+	}
+	rawYAML := []byte(request.Content)
+
+	kvStore, err := store.NewValkeyStore()
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to connect to database",
+		})
+	}
+	defer kvStore.Close()
+
+	existing, err := readExistingMeta(ctx, kvStore, templateID)
+	if err != nil {
+		slog.Warn("Failed to read existing meta", "id", templateID, "error", err)
+	}
+	if existing == nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Template not found",
+		})
+	}
+
+	envelopeJSON, metaJSON, checksum, err := buildTemplateRecord(&yamlTemplate, rawYAML, existing.IsCustom, existing.Created)
+	if err != nil {
+		slog.Error("Failed to build template record", "id", templateID, "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to encode template",
+		})
+	}
+
+	if err := persistTemplateRecord(ctx, kvStore, templateID, envelopeJSON, metaJSON); err != nil {
+		slog.Error("Failed to persist template", "id", templateID, "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to store template",
+		})
+	}
+
+	if err := publishNotifyAgents(templateID, "sirius-api"); err != nil {
+		slog.Warn("Failed to publish notify_agents", "id", templateID, "error", err)
+	}
+
+	return c.JSON(fiber.Map{
+		"id":       templateID,
+		"checksum": checksum,
+		"message":  "Template updated successfully",
+	})
 }
 
 func DeployAgentTemplate(c *fiber.Ctx) error {

--- a/sirius-api/handlers/agent_template_handler_test.go
+++ b/sirius-api/handlers/agent_template_handler_test.go
@@ -133,6 +133,36 @@ detection: {}
 	}
 }
 
+// TestBuildTemplateRecord_PreservesCreated covers the update path: when
+// UpdateAgentTemplate reads the existing meta and re-builds the record,
+// it passes through the original `created` timestamp and the original
+// `is_custom` flag (so editing a built-in does not silently flip it to
+// custom). The envelope's `updated` field still moves to "now".
+func TestBuildTemplateRecord_PreservesCreated(t *testing.T) {
+	tpl := parseFixture(t)
+	raw := []byte(fixtureYAML)
+	original := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	envBytes, _, _, err := buildTemplateRecord(tpl, raw, false, original)
+	if err != nil {
+		t.Fatalf("buildTemplateRecord returned error: %v", err)
+	}
+
+	var envelope templateInfoRecord
+	if err := json.Unmarshal(envBytes, &envelope); err != nil {
+		t.Fatalf("envelope decode: %v", err)
+	}
+	if !envelope.Created.Equal(original) {
+		t.Errorf("Created should be preserved; got %v want %v", envelope.Created, original)
+	}
+	if envelope.IsCustom {
+		t.Error("IsCustom should remain false when caller passes false (built-in edit)")
+	}
+	if envelope.Updated.Before(original) || envelope.Updated.Equal(original) {
+		t.Errorf("Updated should advance past Created; got Updated=%v Created=%v", envelope.Updated, original)
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/sirius-ui/src/components/scanner/agent/AgentTemplatesTab.tsx
+++ b/sirius-ui/src/components/scanner/agent/AgentTemplatesTab.tsx
@@ -26,6 +26,7 @@ const AgentTemplatesTab: React.FC = () => {
   const { data: templates, isLoading } =
     api.agentTemplates.getTemplates.useQuery();
   const uploadMutation = api.agentTemplates.uploadTemplate.useMutation();
+  const updateMutation = api.agentTemplates.updateTemplate.useMutation();
   const deleteMutation = api.agentTemplates.deleteTemplate.useMutation();
   const testMutation = api.agentTemplates.testTemplate.useMutation();
   const utils = api.useContext();
@@ -113,17 +114,26 @@ const AgentTemplatesTab: React.FC = () => {
       console.log("🔍 Form Data:", template);
       console.log("📄 Generated YAML:\n", yamlContent);
 
-      // Upload template to backend
-      await uploadMutation.mutateAsync({
-        content: yamlContent,
-        filename: filename,
-        author: template.author,
-      });
+      if (editingTemplate) {
+        await updateMutation.mutateAsync({
+          id: editingTemplate.id,
+          content: yamlContent,
+          filename: filename,
+          author: template.author,
+        });
+      } else {
+        await uploadMutation.mutateAsync({
+          content: yamlContent,
+          filename: filename,
+          author: template.author,
+        });
+      }
 
-      // Refresh the template list
       await utils.agentTemplates.getTemplates.invalidate();
 
-      // Navigate back to library
+      // Clear edit target so the next Save Changes doesn't accidentally
+      // re-target an old id when the operator opens a different template.
+      setEditingTemplate(null);
       setCurrentView("library");
     } catch (error) {
       console.error("Failed to save template:", error);

--- a/sirius-ui/src/server/api/routers/agent-templates.ts
+++ b/sirius-ui/src/server/api/routers/agent-templates.ts
@@ -26,6 +26,8 @@ const validateTemplateSchema = z.object({
 const updateTemplateSchema = z.object({
   id: z.string(),
   content: z.string(),
+  filename: z.string().optional(),
+  author: z.string().optional(),
 });
 
 const testTemplateSchema = z.object({
@@ -150,7 +152,11 @@ export const agentTemplatesRouter = createTRPCRouter({
             headers: {
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({ content: input.content }),
+            body: JSON.stringify({
+              content: input.content,
+              filename: input.filename,
+              author: input.author,
+            }),
           }
         );
 

--- a/tasks/scanner-templates-fix.json
+++ b/tasks/scanner-templates-fix.json
@@ -95,8 +95,8 @@
     "id": "3",
     "title": "PR 3: Custom Template Upload Writes Envelope + Meta + Triggers Sync",
     "description": "Make UploadAgentTemplate produce records the agent's sync server understands, and trigger that sync.",
-    "details": "Compute sha256, build the standard JSON envelope with base64 content, write to template:custom:<id>; write template:meta:<id> with is_custom: true; publish to agent.template.sync.jobs to trigger the existing notify-agents path.",
-    "status": "pending",
+    "details": "Compute sha256, build the standard JSON envelope with base64 content, write to template:custom:<id>; write template:meta:<id> with is_custom: true; publish to agent.template.sync.jobs to trigger the existing notify-agents path. Merged as Sirius#122 + app-agent#2 on 2026-04-22.",
+    "status": "done",
     "priority": "high",
     "dependencies": ["2"],
     "subtasks": []
@@ -105,8 +105,8 @@
     "id": "4",
     "title": "PR 4: UpdateAgentTemplate Handler + UI Wiring",
     "description": "Implement the stub UpdateAgentTemplate; route Save Changes to update vs upload based on editingTemplate.",
-    "details": "Mirror the upload path but require existence; UI handleSaveTemplate calls updateMutation when editingTemplate set.",
-    "status": "pending",
+    "details": "Mirror the upload path but require existence; UI handleSaveTemplate calls updateMutation when editingTemplate set. PR opened from feature/scanner-templates-fix-pr4.",
+    "status": "in_progress",
     "priority": "medium",
     "dependencies": ["3"],
     "subtasks": []


### PR DESCRIPTION
## Summary

Sprint PR 4 of the [scanner-templates-fix playbook](documentation/dev-notes/scanner-templates-fix-pr-playbook.md). Resolves the latent Bug 4: editing a custom agent template silently created a near-duplicate via the upload path because:

1. \`sirius-api/handlers.UpdateAgentTemplate\` was a stub returning success without writing.
2. \`AgentTemplatesTab.handleSaveTemplate\` always called \`uploadMutation\`, never \`updateTemplate\`, even when \`editingTemplate\` was set.

### Backend
- Replaced the \`UpdateAgentTemplate\` stub with a real handler that:
  - validates URL \`:id\` and rejects mismatch with the parsed YAML id (400)
  - returns 404 when \`template:meta:<id>\` does not exist
  - reads the existing meta and preserves \`IsCustom\` + original \`Created\` (built-in templates stay built-in; \`Updated\` still moves)
  - writes envelope + meta via a new shared \`persistTemplateRecord\` helper extracted from \`UploadAgentTemplate\` (same rollback-on-meta-failure semantics)
  - publishes \`notify_agents\` to \`agent.template.sync.jobs\` (PR 3 contract)

### Frontend
- \`AgentTemplatesTab.handleSaveTemplate\` now branches on \`editingTemplate\`: \`updateMutation\` for edits, \`uploadMutation\` for new templates.
- Clears \`editingTemplate\` on success so the next open of a different template does not retarget the wrong id.
- tRPC \`updateTemplateSchema\` extended with optional \`filename\` + \`author\`, both forwarded to the backend to match the upload contract.

### Tests
- \`TestBuildTemplateRecord_PreservesCreated\` covers the update path's \`IsCustom\` / \`Created\` passthrough and asserts \`Updated\` still advances.
- Existing \`go test ./handlers/...\` passes locally.

## Verification (post-deploy)

1. Open a custom agent template in the UI builder, change the description, Save Changes; refresh and confirm the change persisted.
2. \`docker exec sirius-valkey valkey-cli GET template:custom:<id>\` shows updated \`updated\` timestamp; \`created\` unchanged.
3. Network tab during Save: only \`/api/trpc/agentTemplates.updateTemplate*\`, no second upload call.
4. Built-in template edit (advanced - currently allowed): \`is_custom\` flag remains \`false\` in \`template:meta:<id>\`.

## Out of scope (filed separately if needed)

- Disabling Edit on built-in templates / copy-on-edit UX.

## Tracker

- Marks PR 4 \`in_progress\` in [tasks/scanner-templates-fix.json](tasks/scanner-templates-fix.json); will flip to \`done\` post-merge along with the next PR's tracker bump.