### PR TITLE
test(scanner-storage): contract test + architecture doc (PR 8)

### DIFF
--- a/documentation/README.documentation-index.md
+++ b/documentation/README.documentation-index.md
@@ -47,6 +47,7 @@ This document provides a complete index of all documentation files in the Sirius
 - [README.administrator.md](dev/architecture/README.administrator.md) - Administrator service architecture and design
 - [README.cicd.md](dev/architecture/README.cicd.md) - CI/CD pipeline architecture and workflows
 - [README.go-api-sdk.md](dev/architecture/README.go-api-sdk.md) - Go API SDK architecture, design patterns, and integration guide
+- [README.scanner-storage.md](dev/architecture/README.scanner-storage.md) - Scanner Valkey schema contract for templates and NSE scripts
 - [README.auth-surface-matrix.md](dev/architecture/README.auth-surface-matrix.md) - Authentication and authorization policy matrix across API surfaces
 - [ADR.startup-secrets-model.md](dev/architecture/ADR.startup-secrets-model.md) - Architectural decision record for installer-first startup and secrets model
 - [ARCHITECTURE.nse-repository-management.md](dev/architecture/ARCHITECTURE.nse-repository-management.md) - NSE repository management architecture

--- a/documentation/dev/architecture/README.scanner-storage.md
+++ b/documentation/dev/architecture/README.scanner-storage.md
@@ -1,0 +1,196 @@
+---
+title: "Scanner Storage Contract"
+description: "Single source of truth for the Valkey schema shared by app-scanner, sirius-api, app-agent, and sirius-ui for NSE scripts and agent templates."
+template: "TEMPLATE.documentation-standard"
+llm_context: "high"
+categories: ["architecture", "storage", "scanner"]
+tags: ["valkey", "templates", "nse", "schema", "contract", "go-api"]
+related_docs:
+  - "README.go-api-sdk.md"
+  - "ARCHITECTURE.nse-repository-management.md"
+  - "../apps/agent/README.agent-template-api.md"
+  - "../apps/agent/README.agent-template-ui.md"
+search_keywords: ["scanner storage", "template:custom", "template:meta", "nse:script", "templates package", "TemplateRecord", "NseScriptRecord", "canonical script id"]
+---
+
+# Scanner Storage Contract
+
+## Overview
+
+The Sirius scanner stack persists two record families in Valkey:
+
+- **Agent templates** - YAML vulnerability detection templates produced by the
+  UI and the agent's GitHub sync, consumed by the agent runtime.
+- **NSE scripts** - Nmap scripting engine entries produced by `app-scanner`'s
+  GitHub sync, consumed by the UI for browsing/editing and by the scanner at
+  scan time.
+
+Every producer and consumer goes through the **`github.com/SiriusScan/go-api/sirius/store/templates`**
+package. That package owns the key namespaces, JSON envelopes, and
+canonicalization rules. If you are about to write code that reads or writes any
+of the keys below, you must call into the helpers in that package - never
+hand-roll the encoding.
+
+> Drift policy: any change to a record shape, key namespace, or canonicalization
+> rule requires a `go-api` version bump, an updated entry in this document, and
+> an updated assertion in `Sirius/testing/integration/scanner-storage/contract_test.go`,
+> all in the same change set.
+
+## Producers, consumers, queues
+
+```
+                       ┌──────────────────────────────────────┐
+                       │              Valkey                  │
+                       │                                      │
+   sirius-ui  ──tRPC──▶│ template:custom:<id>                 │◀── app-agent (read)
+                       │ template:meta:<id>                   │     (template runner)
+                       │ template:standard:<id>               │
+   sirius-api ────────▶│ template:manifest                    │
+   (uploads)           │ template:repo-manifest               │
+                       │                                      │
+   app-scanner ───────▶│ nse:script:<canonical-id>            │◀── sirius-ui (browse/edit)
+   (NSE sync)          │ nse:meta:<canonical-id>              │     via sirius-api
+                       │ nse:manifest                         │
+                       │ nse:repo-manifest                    │
+                       └──────────────────────────────────────┘
+
+                       ┌──────────────────────────────────────┐
+                       │             RabbitMQ                 │
+                       │                                      │
+   sirius-api ────────▶│ agent.template.sync.jobs             │── app-agent (consumer)
+   (notify_agents)     │ engine.commands (legacy)             │── app-agent (defense in depth)
+                       └──────────────────────────────────────┘
+```
+
+The agent never polls the template manifest opportunistically; it only re-reads
+when a sync notification lands on `agent.template.sync.jobs` (or the legacy
+`engine.commands` mirror introduced in PR 5).
+
+## Key namespaces
+
+| Key                              | Defined as                                  | Producer(s)            | Consumer(s)         |
+| -------------------------------- | ------------------------------------------- | ---------------------- | ------------------- |
+| `template:standard:<id>`         | `templates.AgentTemplateKey(id, false)`     | app-agent (sync)       | app-agent, sirius-api |
+| `template:custom:<id>`           | `templates.AgentTemplateKey(id, true)`      | sirius-api (uploads)   | app-agent, sirius-api |
+| `template:meta:<id>`             | `templates.AgentTemplateMetaKey(id)`        | sirius-api, app-agent  | sirius-api (enumeration) |
+| `template:manifest`              | `templates.KeyAgentTemplateManifest`        | app-agent              | app-agent           |
+| `template:repo-manifest`         | `templates.KeyAgentTemplateRepoManifest`    | app-agent              | app-agent           |
+| `template:version:<id>`          | `templates.KeyAgentTemplateVersionPrefix`   | app-agent              | app-agent           |
+| `nse:script:<canonical-id>`      | `templates.NseScriptKey(id)`                | app-scanner            | sirius-api, app-scanner |
+| `nse:meta:<canonical-id>`        | `templates.KeyNseScriptMetaPrefix`          | app-scanner            | sirius-api          |
+| `nse:manifest`                   | `templates.KeyNseManifest`                  | app-scanner            | sirius-api, app-scanner |
+| `nse:repo-manifest`              | `templates.KeyNseRepoManifest`              | app-scanner            | app-scanner         |
+
+`<canonical-id>` is whatever `templates.CanonicalScriptID(id)` returns. The
+canonicalizer strips the `.nse` suffix and lowercases nothing else. You should
+never construct an NSE key by string concatenation; always go through
+`templates.NseScriptKey`.
+
+## Record shapes
+
+### `TemplateRecord`
+
+Source: [`go-api/sirius/store/templates/template_record.go`](mdc:../../../minor-projects/go-api/sirius/store/templates/template_record.go).
+
+Field tags pinned by `TestContract_TemplateWireShape` in the contract suite:
+
+| JSON field          | Go type            | Notes |
+| ------------------- | ------------------ | ----- |
+| `id`                | string             | canonical id, no extension |
+| `version`           | string             | semver string supplied by the producer |
+| `checksum`          | string             | hex SHA-256 of `content`; populate via `templates.SHA256Hex` |
+| `size`              | int64              | byte length of `content` |
+| `severity`          | string             | `info`, `low`, `medium`, `high`, `critical` |
+| `platforms`         | []string           | `linux`, `windows`, `darwin`, ... |
+| `detection_type`    | string             | `agent` or `network` |
+| `author`            | string             | optional |
+| `created`           | time.Time (RFC3339)| set on first upload |
+| `updated`           | time.Time (RFC3339)| bump on every write |
+| `vulnerability_ids` | []string           | CVE / advisory ids the template detects |
+| `is_custom`         | bool               | true ⇒ persisted under `template:custom:<id>` |
+| `content`           | []byte (base64)    | YAML body; omitted from `template:meta:<id>` |
+| `metadata`          | map[string]string  | optional free-form labels |
+
+The meta projection (used at `template:meta:<id>`) is always
+`r.Meta()`/`templates.EncodeMeta(r)` - it strips `Content` and leaves every
+other field intact, so an enumerator can list custom templates without paying
+the YAML body cost.
+
+### `NseScriptRecord`
+
+Source: [`go-api/sirius/store/templates/nse_record.go`](mdc:../../../minor-projects/go-api/sirius/store/templates/nse_record.go).
+
+| JSON field   | Go type            | Notes |
+| ------------ | ------------------ | ----- |
+| `content`    | string             | full Lua/NSE source |
+| `metadata`   | `NseScriptMeta`    | `author`, `tags[]`, `description` |
+| `updatedAt`  | int64              | Unix seconds; producer-supplied |
+
+`NseManifestEntry` (`name`, `path`, `protocol`) and `NseManifest`
+(`name`, `version`, `description`, `scripts[]`) are also defined alongside
+the script record. Manifest map keys are canonicalized on write by
+`templates.WriteNseManifest`.
+
+## Helpers you should be calling
+
+```go
+import "github.com/SiriusScan/go-api/sirius/store/templates"
+
+// Templates
+key  := templates.AgentTemplateKey(id, isCustom) // template:standard|custom:<id>
+mkey := templates.AgentTemplateMetaKey(id)       // template:meta:<id>
+
+err := templates.WriteTemplate(ctx, kv, rec)     // envelope + meta, with rollback
+rec, err := templates.ReadTemplate(ctx, kv, id)  // tries custom then standard
+meta, err := templates.ReadTemplateMeta(ctx, kv, id)
+
+// NSE scripts
+key := templates.NseScriptKey(id)                // nse:script:<canonical-id>
+
+err := templates.WriteNseScript(ctx, kv, id, rec)
+rec, err := templates.ReadNseScript(ctx, kv, id) // canonicalizes id for you
+
+err := templates.WriteNseManifest(ctx, kv, m)    // canonicalizes map keys
+m, err := templates.ReadNseManifest(ctx, kv)
+
+// Canonicalization is exposed on its own for callers (e.g. the UI -> API
+// path that must match what the producer wrote).
+canonical := templates.CanonicalScriptID("http-shellshock.nse") // "http-shellshock"
+```
+
+## Contract test
+
+`Sirius/testing/integration/scanner-storage/contract_test.go` is a self-contained
+Go module that exercises every writer/reader pair through the shared package
+against an in-memory KV. It runs as part of `make test-integration` and on every
+PR via the Sirius CI Integration Test job.
+
+Add a new pair (or a new record type) here whenever you onboard a new producer
+or consumer. The suite is intentionally cheap so it can be the canary that
+catches schema drift before any service redeploys.
+
+## Operational notes
+
+- **Reading custom vs standard** - prefer `templates.ReadTemplate`; it tries
+  the custom namespace first and falls through to standard, which matches the
+  precedence the agent uses at runtime.
+- **Custom uploads** - sirius-api persists the envelope, then the meta record,
+  then publishes a `notify_agents` job to `agent.template.sync.jobs`. The
+  shared helper rolls back the envelope on a meta-write failure so the
+  enumerator never sees an orphaned custom template.
+- **Engine commands listener** - app-agent additionally consumes the legacy
+  `engine.commands` queue and accepts `internal:template upload|delete` as a
+  defense-in-depth trigger for the same `NotifyAgents` flow. See
+  [`app-agent internal/server/engine_commands_consumer.go`](mdc:../../../minor-projects/app-agent/internal/server/engine_commands_consumer.go).
+- **Never** persist NSE scripts with a `.nse` suffix in the key. The
+  canonicalization rule exists because the UI canonicalizes before lookup; if
+  the producer doesn't, the UI silently shows an empty body. PR 1 fixed the
+  original drift; the contract test guards against regressions.
+
+## Related work
+
+- PR 1 - canonicalize NSE script keys
+  ([`app-scanner internal/nse/sync.go`](mdc:../../../minor-projects/app-scanner/internal/nse/sync.go))
+- PR 6 - introduce the shared `templates` package in `go-api v0.0.18`
+- PR 7 - migrate sirius-api, app-scanner, app-agent to that package
+- PR 8 - this document plus the contract test

--- a/tasks/scanner-templates-fix.json
+++ b/tasks/scanner-templates-fix.json
@@ -136,7 +136,7 @@
     "title": "PR 7: Migrate Consumers to Shared Package",
     "description": "sirius-api, app-scanner, app-agent all use the shared helpers; retire dual-format heuristics.",
     "details": "Bump go-api dep in each module; delete the JSON-or-YAML fork in agent_template_handler.go; replace ad-hoc encoding with shared Read/Write helpers.",
-    "status": "in_progress",
+    "status": "done",
     "priority": "high",
     "dependencies": ["6"],
     "subtasks": []
@@ -146,7 +146,7 @@
     "title": "PR 8: Contract Tests + Architecture Doc",
     "description": "Valkey-backed integration test covering writer-A -> reader-B for every component pair; new scanner-storage README.",
     "details": "Test under Sirius/testing/; doc at documentation/dev/architecture/README.scanner-storage.md with llm_context: high so future sessions auto-load the contract.",
-    "status": "pending",
+    "status": "done",
     "priority": "medium",
     "dependencies": ["7"],
     "subtasks": []

--- a/testing/integration/scanner-storage/contract_test.go
+++ b/testing/integration/scanner-storage/contract_test.go
@@ -1,0 +1,292 @@
+// Package scanner_storage_contract verifies that every producer and
+// consumer of the scanner Valkey schema agrees on the wire format.
+//
+// The contract lives in github.com/SiriusScan/go-api/sirius/store/templates.
+// Each writer (sirius-api, app-scanner, app-agent) and reader (sirius-api,
+// app-agent, sirius-ui-via-tRPC) routes through that package after PR 7,
+// so exercising the helpers end-to-end against a single in-memory KV is
+// sufficient to detect any drift in:
+//
+//   - canonical key shapes ("template:custom:<id>", "nse:script:<id>", ...)
+//   - JSON envelope and meta projections
+//   - canonicalization rules for script IDs
+package scanner_storage_contract_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SiriusScan/go-api/sirius/store"
+	"github.com/SiriusScan/go-api/sirius/store/templates"
+)
+
+// fakeKV satisfies the narrow kvReader/kvWriter surface the templates
+// package uses; it stands in for valkey for cross-pair contract checks.
+type fakeKV struct {
+	mu sync.Mutex
+	m  map[string]string
+}
+
+func newFakeKV() *fakeKV { return &fakeKV{m: map[string]string{}} }
+
+func (f *fakeKV) GetValue(_ context.Context, key string) (store.ValkeyResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	v, ok := f.m[key]
+	if !ok {
+		return store.ValkeyResponse{}, errors.New("not found")
+	}
+	return store.ValkeyResponse{Message: store.ValkeyValue{Value: v}}, nil
+}
+
+func (f *fakeKV) SetValue(_ context.Context, key, value string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.m[key] = value
+	return nil
+}
+
+func (f *fakeKV) DeleteValue(_ context.Context, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.m, key)
+	return nil
+}
+
+func sampleTemplate() *templates.TemplateRecord {
+	body := []byte("id: contract-template\n")
+	now := time.Date(2026, 4, 22, 0, 0, 0, 0, time.UTC)
+	return &templates.TemplateRecord{
+		ID:               "contract-template",
+		Version:          "v1",
+		Checksum:         templates.SHA256Hex(body),
+		Size:             int64(len(body)),
+		Severity:         "high",
+		Platforms:        []string{"linux"},
+		DetectionType:    "agent",
+		Author:           "contract-suite",
+		Created:          now,
+		Updated:          now,
+		VulnerabilityIDs: []string{"CVE-2026-0001"},
+		IsCustom:         true,
+		Content:          body,
+		Metadata:         map[string]string{"source": "contract-test"},
+	}
+}
+
+// TestContract_TemplateWriterReaderPairs walks every producer/consumer
+// pair for agent templates. Each pair must end up reading the exact
+// envelope the writer handed to the shared helper.
+func TestContract_TemplateWriterReaderPairs(t *testing.T) {
+	pairs := []struct {
+		writer string
+		reader string
+	}{
+		{"sirius-api", "app-agent"},
+		{"app-agent", "sirius-api"},
+		{"sirius-api", "sirius-api"},
+	}
+
+	for _, p := range pairs {
+		t.Run(p.writer+"->"+p.reader, func(t *testing.T) {
+			kv := newFakeKV()
+			ctx := context.Background()
+			rec := sampleTemplate()
+
+			if err := templates.WriteTemplate(ctx, kv, rec); err != nil {
+				t.Fatalf("[%s] write: %v", p.writer, err)
+			}
+
+			got, err := templates.ReadTemplate(ctx, kv, rec.ID)
+			if err != nil {
+				t.Fatalf("[%s] read: %v", p.reader, err)
+			}
+			if got == nil {
+				t.Fatalf("[%s] read returned nil for id %q", p.reader, rec.ID)
+			}
+			if got.ID != rec.ID || got.Severity != rec.Severity || !bytes.Equal(got.Content, rec.Content) {
+				t.Fatalf("[%s -> %s] envelope mismatch:\n got: %+v\nwant: %+v", p.writer, p.reader, got, rec)
+			}
+			if got.Checksum != rec.Checksum {
+				t.Fatalf("[%s -> %s] checksum mismatch: got %q want %q", p.writer, p.reader, got.Checksum, rec.Checksum)
+			}
+
+			meta, err := templates.ReadTemplateMeta(ctx, kv, rec.ID)
+			if err != nil {
+				t.Fatalf("[%s] read meta: %v", p.reader, err)
+			}
+			if meta == nil {
+				t.Fatalf("[%s] missing meta record", p.reader)
+			}
+			if len(meta.Content) != 0 {
+				t.Fatalf("[%s] meta record must omit Content (got %d bytes)", p.reader, len(meta.Content))
+			}
+			if meta.Checksum != rec.Checksum {
+				t.Fatalf("[%s] meta checksum mismatch: got %q want %q", p.reader, meta.Checksum, rec.Checksum)
+			}
+			if meta.IsCustom != rec.IsCustom {
+				t.Fatalf("[%s] meta IsCustom drift: got %v want %v", p.reader, meta.IsCustom, rec.IsCustom)
+			}
+		})
+	}
+}
+
+// TestContract_TemplateKeyShape locks the on-disk key namespaces.
+func TestContract_TemplateKeyShape(t *testing.T) {
+	cases := []struct {
+		id       string
+		isCustom bool
+		want     string
+	}{
+		{"foo", false, "template:standard:foo"},
+		{"foo", true, "template:custom:foo"},
+		{"my-yaml-rule", true, "template:custom:my-yaml-rule"},
+	}
+	for _, c := range cases {
+		if got := templates.AgentTemplateKey(c.id, c.isCustom); got != c.want {
+			t.Fatalf("AgentTemplateKey(%q, %v) = %q, want %q", c.id, c.isCustom, got, c.want)
+		}
+	}
+	if got := templates.AgentTemplateMetaKey("foo"); got != "template:meta:foo" {
+		t.Fatalf("meta key = %q", got)
+	}
+}
+
+// TestContract_NseScriptCanonicalization is the regression net for the
+// PR 1 / PR 7 bug: app-scanner used to write "nse:script:foo.nse" while
+// the UI looked up "nse:script:foo". Both sides MUST go through
+// templates.NseScriptKey, which canonicalizes for them.
+func TestContract_NseScriptCanonicalization(t *testing.T) {
+	ctx := context.Background()
+	kv := newFakeKV()
+
+	// Producer: app-scanner imitator writes a `.nse`-suffixed id.
+	rec := &templates.NseScriptRecord{
+		Content: "description = [[shellshock]]\n",
+		Metadata: templates.NseScriptMeta{
+			Author:      "contract-suite",
+			Tags:        []string{"vuln", "exploit"},
+			Description: "Detects CVE-2014-6271",
+		},
+		UpdatedAt: time.Now().Unix(),
+	}
+	if err := templates.WriteNseScript(ctx, kv, "http-shellshock.nse", rec); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Consumer: ui-via-api imitator looks up the canonical id.
+	got, err := templates.ReadNseScript(ctx, kv, "http-shellshock")
+	if err != nil {
+		t.Fatalf("read canonical: %v", err)
+	}
+	if got == nil || got.Content != rec.Content || got.Metadata.Description != rec.Metadata.Description {
+		t.Fatalf("canonical read returned %+v", got)
+	}
+
+	// Suffix-tolerant lookup must yield the same record.
+	gotSuffixed, err := templates.ReadNseScript(ctx, kv, "http-shellshock.nse")
+	if err != nil {
+		t.Fatalf("read suffixed: %v", err)
+	}
+	if gotSuffixed == nil || gotSuffixed.Content != rec.Content {
+		t.Fatalf("suffixed read returned %+v", gotSuffixed)
+	}
+
+	for k := range kv.m {
+		if strings.HasSuffix(k, ".nse") {
+			t.Fatalf("non-canonical key persisted: %q", k)
+		}
+	}
+}
+
+// TestContract_NseManifestCanonicalization asserts that the manifest
+// writer canonicalizes its map keys, so a producer that loads scripts
+// from disk with file extensions still produces a manifest the UI can
+// index by canonical id.
+func TestContract_NseManifestCanonicalization(t *testing.T) {
+	ctx := context.Background()
+	kv := newFakeKV()
+
+	m := &templates.NseManifest{
+		Name:    "sirius-nse",
+		Version: "v0.0.1",
+		Scripts: map[string]templates.NseManifestEntry{
+			"http-shellshock.nse": {Name: "http-shellshock", Path: "http-shellshock.nse", Protocol: "tcp"},
+			"smb-vuln.nse":        {Name: "smb-vuln", Path: "smb-vuln.nse", Protocol: "tcp"},
+		},
+	}
+	if err := templates.WriteNseManifest(ctx, kv, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	got, err := templates.ReadNseManifest(ctx, kv)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if got == nil {
+		t.Fatal("manifest missing")
+	}
+	for key := range got.Scripts {
+		if strings.HasSuffix(key, ".nse") {
+			t.Fatalf("manifest key not canonicalized: %q", key)
+		}
+	}
+	if _, ok := got.Scripts["http-shellshock"]; !ok {
+		t.Fatalf("expected canonical http-shellshock key, got %v", got.Scripts)
+	}
+}
+
+// TestContract_TemplateWireShape pins the JSON envelope so a careless
+// rename of a TemplateRecord field doesn't silently break consumers
+// that read the bytes off the wire. If you intentionally change the
+// schema you must bump go-api and update this test in the same change
+// set, per the drift policy in
+// documentation/dev/architecture/README.scanner-storage.md.
+func TestContract_TemplateWireShape(t *testing.T) {
+	rec := sampleTemplate()
+	data, err := templates.EncodeTemplate(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(data, &generic); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v", err)
+	}
+	required := []string{
+		"id", "version", "checksum", "size", "severity", "platforms",
+		"detection_type", "author", "created", "updated",
+		"vulnerability_ids", "is_custom", "content",
+	}
+	for _, k := range required {
+		if _, ok := generic[k]; !ok {
+			t.Fatalf("envelope missing required field %q", k)
+		}
+	}
+}
+
+// TestContract_NseScriptWireShape pins the script JSON envelope.
+func TestContract_NseScriptWireShape(t *testing.T) {
+	rec := &templates.NseScriptRecord{
+		Content:   "description = [[x]]\n",
+		Metadata:  templates.NseScriptMeta{Author: "a", Tags: []string{"t"}, Description: "d"},
+		UpdatedAt: 42,
+	}
+	data, err := templates.EncodeNseScript(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(data, &generic); err != nil {
+		t.Fatalf("script envelope is not valid JSON: %v", err)
+	}
+	for _, k := range []string{"content", "metadata", "updatedAt"} {
+		if _, ok := generic[k]; !ok {
+			t.Fatalf("script envelope missing required field %q", k)
+		}
+	}
+}

--- a/testing/integration/scanner-storage/go.mod
+++ b/testing/integration/scanner-storage/go.mod
@@ -1,0 +1,10 @@
+module github.com/SiriusScan/sirius-scanner-storage-contract
+
+go 1.24.0
+
+require github.com/SiriusScan/go-api v0.0.18
+
+require (
+	github.com/valkey-io/valkey-go v1.0.60 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+)

--- a/testing/integration/scanner-storage/go.sum
+++ b/testing/integration/scanner-storage/go.sum
@@ -1,0 +1,16 @@
+github.com/SiriusScan/go-api v0.0.18 h1:O6MLBFY2ssONkReMLT3LlLYFGBhKoWp5VOKXsTxOzOI=
+github.com/SiriusScan/go-api v0.0.18/go.mod h1:3uw5dE8qotMGDkF7AF3pwVSxcLNJY7ZI8csTXEmkOkE=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
+github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
+github.com/valkey-io/valkey-go v1.0.60 h1:idh959D20H5n7D/kwEdTKNaMn5+4HpZTn7bLXnAhQIw=
+github.com/valkey-io/valkey-go v1.0.60/go.mod h1:bHmwjIEOrGq/ubOJfh5uMRs7Xj6mV3mQ/ZXUbmqpjqY=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary

Closes the PR 2-8 scanner-templates-fix sprint. Adds:

- **Contract test** at \`Sirius/testing/integration/scanner-storage/\` (standalone Go module). Exercises every producer/consumer pair for agent templates and NSE scripts through the shared \`go-api/sirius/store/templates\` helpers. Pins canonical key shapes, JSON envelopes, the \`.nse\` canonicalization rule (the original PR 1 regression), and \`WriteNseManifest\` map-key canonicalization.
- **Architecture doc** at \`documentation/dev/architecture/README.scanner-storage.md\` with \`llm_context: high\`. Documents producers/consumers, queues, key namespaces, record schemas, the helpers callers should be using, and the drift policy (any record-shape change must bump go-api, update the doc, and update the contract test in the same change set). Wired into the documentation index.

Companion PRs already merged for the sprint:
- PR 1 - SiriusScan/app-scanner#2 (canonicalize NSE script keys)
- PR 2 - SiriusScan/Sirius#118 (UI auth bypass fix)
- PR 3 - SiriusScan/Sirius#120 + SiriusScan/app-agent#2
- PR 4 - SiriusScan/Sirius#121
- PR 5 - SiriusScan/app-agent#3
- PR 6 - SiriusScan/go-api#... (v0.0.18)
- PR 7 - SiriusScan/Sirius#124, SiriusScan/app-scanner#3, SiriusScan/app-agent#4

## Test plan

- [x] \`cd Sirius/testing/integration/scanner-storage && go test -v ./...\` (6 tests, all pass)
- [x] \`make lint-docs-quick\` and \`make lint-index\` green