### PR TITLE
fix(ui): route dashboard View Hosts CTAs to /environment

### DIFF
--- a/sirius-ui/src/pages/dashboard.tsx
+++ b/sirius-ui/src/pages/dashboard.tsx
@@ -178,7 +178,7 @@ const Dashboard: NextPage = () => {
                   )}% online`
                 : "No hosts discovered"
             }
-            cta={{ label: "View Hosts", href: "/host" }}
+            cta={{ label: "View Hosts", href: "/environment" }}
             variant="default"
           />
         </div>
@@ -321,7 +321,7 @@ const Dashboard: NextPage = () => {
                   icon={<Server className="h-5 w-5" />}
                   title="View All Hosts"
                   description="Browse discovered hosts"
-                  onClick={() => router.push("/host")}
+                  onClick={() => router.push("/environment")}
                 />
                 <ActionButton
                   icon={


### PR DESCRIPTION
## Summary
The dashboard had two "View Hosts" CTAs linking to `/host`, which 404s. The host-list page lives at `/environment` — the `/host/` route is only defined as `pages/host/[ip].tsx` (the dynamic detail page), with no index.

Fixes the CTAs in two places:
- `src/pages/dashboard.tsx:181` — stats-card CTA href
- `src/pages/dashboard.tsx:324` — ActionButton `router.push`

Both now route to `/environment`.

## Test plan
- [ ] On the dashboard, click the **View Hosts** link on the host stats card → lands on `/environment`, no 404
- [ ] On the dashboard, click the **View All Hosts** quick-action button → lands on `/environment`, no 404
- [ ] Regression: `/environment` still renders the host table normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)