### PR TITLE
docs: close Community release stage

### DIFF
--- a/programs/bifurcation/PROGRAM.md
+++ b/programs/bifurcation/PROGRAM.md
@@ -133,35 +133,34 @@ Tasks:
 - [x] Validate and review the task 1.4 release-train implementation
 - [x] Cross the human gate to push, review, and merge the feature branch
 - [x] Confirm main CI produced the exact-SHA core build inventory
-- [ ] Cross the human gate to tag and publish `v1.1.0`
-- [ ] Verify all six images and `core-manifest.yaml`; mark task 1.4 done
-- [ ] Implement and verify task 1.5 SBOM generation and Cosign signing
-- [ ] Update this file with stage outcomes
+- [x] Cross the human gate to tag and publish `v1.1.0`
+- [x] Verify all six images and `core-manifest.yaml`; mark task 1.4 done
+- [x] Implement and verify task 1.5 SBOM generation and Cosign signing
+- [x] Update this file with stage outcomes
 
 Current task:
 
-- `task_id`: `bifurcation.s2.t004`
+- `task_id`: `bifurcation.s2.t005`
 - `stage`: `2 Core Release Train`
-- `cycle`: `5`
+- `cycle`: `6`
 - `attempt`: `1`
-- `assigned_role`: `grok`
+- `assigned_role`: `parent`
 - `criteria`:
-  - The release workflow generates platform-scoped Syft SBOM assets for each of the six
-    public image indexes using exact linux/amd64 and linux/arm64 child digests.
-  - The six release image manifests are signed with Cosign and admit verification.
-  - Release publication fails closed if SBOM generation, signing, or verification
-    fails.
-  - No Git tag, GitHub Release, package tag, or external deployment is created during
-    implementation and validation.
+  - `v1.1.0` resolves to the exact main commit with a successful core-build inventory.
+  - All six public image tags resolve to the manifest digests in `core-manifest.yaml`.
+  - Twelve platform-scoped CycloneDX SBOM assets are published.
+  - The release workflow keyless-signs and verifies all six image indexes before
+    publication, and the follow-up public verification workflow succeeds.
 - `validation`:
-  - `bash scripts/test-core-manifest.sh`
-  - Workflow YAML parsing and pinned-tool checksum validation
-  - Focused SBOM/signing release-contract tests
+  - `gh run view 30578119633`
+  - `gh release view v1.1.0`
+  - `gh run view 30578823485`
+  - Local release-asset and live-digest validation
 - `verdict`: `accepted`
 - `loop_decision`: `human_gate`
-- `next_action`: Obtain explicit approval to push the cycle-5 branch, open and merge
-  its pull request, and confirm main CI before returning to the separate `v1.1.0`
-  tag-and-publish human gate.
+- `next_action`: Obtain explicit approval before creating the three private
+  `OpenSecurity-Infosec` repositories, teams, package namespaces, or credentials for
+  Stage 3.
 
 Cycle 1 evidence:
 
@@ -233,16 +232,36 @@ Cycle 5 evidence:
 - Decision: task `bifurcation.s2.t004` accepted locally; program waits before pushing
   the branch or opening a pull request.
 
+Cycle 6 evidence:
+
+- Pull request 133 merged as
+  `b61b47b468cfc5c837a5bde50eeafe52df4fe10d`; main CI run 30574501048 succeeded and
+  produced a non-expired exact-commit `core-build-inventory`.
+- Human approval was received to create annotated tag `v1.1.0` at that commit and run
+  the public release workflow.
+- Publish run 30578119633 succeeded through inventory resolution, write-once retagging,
+  public compose smoke, 12 platform SBOMs, canonical OIDC signing, draft asset
+  re-validation, final Cosign verification, and publication.
+- Release `v1.1.0` contains `core-manifest.yaml` and all 12 expected CycloneDX assets.
+  Local validation matched all six live GHCR digests to the manifest.
+- Follow-up verification run 30578823485 succeeded for anonymous GHCR and release
+  manifest checks.
+- Tasks 1.4 and 1.5 and the Phase 1 parent are marked done.
+- Evaluation:
+  `programs/bifurcation/evaluations/bifurcation.s2.t005.md`.
+- Decision: Stage 2 is complete; the program waits at the private-infrastructure human
+  gate before Stage 3.
+
 ## Current loop state
 
 ```yaml
-current_task_id: bifurcation.s2.t004
-cycle: 5
+current_task_id: bifurcation.s2.t005
+cycle: 6
 attempt: 1
 status: waiting
 verdict: accepted
 loop_decision: human_gate
-next_action: Obtain approval to push, review, and merge the cycle-5 release gate changes.
+next_action: Obtain approval before creating private repositories or infrastructure.
 ```
 
 ## Stage 3: Private Supply Chain

--- a/programs/bifurcation/evaluations/bifurcation.s2.t005.md
+++ b/programs/bifurcation/evaluations/bifurcation.s2.t005.md
@@ -1,0 +1,44 @@
+---
+goal_id: bifurcation
+task_id: bifurcation.s2.t005
+run_id: parent-bifurcation-s2-t005-cycle6-20260730
+execution_kind: parent
+cycle: 6
+attempt: 1
+evaluator_role: parent
+evaluated_at: "2026-07-30T20:25:00Z"
+evidence_paths: "PR 133; main run 30574501048; publish run 30578119633; release v1.1.0; verification run 30578823485"
+criteria:
+  - id: exact-release-source
+    status: pass
+    evidence:
+      - "Annotated tag v1.1.0 resolves to b61b47b468cfc5c837a5bde50eeafe52df4fe10d."
+      - "Main run 30574501048 succeeded with a non-expired core-build-inventory artifact."
+  - id: six-image-manifest
+    status: pass
+    evidence:
+      - "Publish run 30578119633 succeeded."
+      - "Local live-digest validation matched all six GHCR tags to core-manifest.yaml."
+  - id: sbom-and-signatures
+    status: pass
+    evidence:
+      - "The release contains 12 non-empty platform-scoped CycloneDX assets."
+      - "The publish workflow keyless-signed and verified all six OCI index digests, then re-verified them before draft=false."
+  - id: public-verification
+    status: pass
+    evidence:
+      - "Follow-up run 30578823485 succeeded for anonymous GHCR and core-manifest checks."
+verdict: accepted
+artifact_verdict: accepted
+loop_decision: human_gate
+residual_risk:
+  - "Private Pro repositories, package namespaces, teams, signing policy, and leakage-prevention controls do not yet exist."
+  - "Stage 3 requires explicit human approval before creating private infrastructure."
+---
+
+# Evaluation
+
+Sirius Community `v1.1.0` is published from the verified main commit with immutable
+image digests, a validated core manifest, complete amd64/arm64 SBOM assets, and
+canonical GitHub OIDC signatures. Stage 2 is accepted and the program stops before
+private infrastructure creation.

--- a/tasks/pro-bifurcation.json
+++ b/tasks/pro-bifurcation.json
@@ -55,7 +55,7 @@
     "title": "PHASE 1: Public-Core Hardening",
     "description": "Fix the data layer, pinning, and release discipline that Pro will depend on. All work is public and benefits Community directly.",
     "details": "Prerequisites discovered in ground-truth review: destructive go-api schema init, migrations skipped in production, unpinned engine components, no release cadence or digest manifest, no SBOM/signing.",
-    "status": "in_progress",
+    "status": "done",
     "priority": "high",
     "dependencies": ["0"],
     "subtasks": [
@@ -93,8 +93,8 @@
         "id": "1.4",
         "title": "Establish release train and digest manifest",
         "description": "Cut v1.1.0 and emit core-manifest.yaml with image digests, component pins, and schema version per release.",
-        "details": "Tag v1.1.0 from hardened HEAD; make publish-release-image-tags.yml + verify-ghcr-release-tag.yml a gated release workflow (release blocked unless all six images retag and verify); generate core-manifest.yaml as a release asset. Publishing the v1.1.0 GitHub Release also requires the task 1.5 SBOM+Cosign fail-closed gate in publish-release-image-tags.yml (do not mark 1.4 done until a real release run succeeds).",
-        "status": "in_progress",
+        "details": "Released v1.1.0 from merge commit b61b47b468cfc5c837a5bde50eeafe52df4fe10d. Publish run 30578119633 resolved exact-commit inventory, write-once retagged and verified all six public images, passed the public compose smoke, attached core-manifest.yaml, and published only after task 1.5 attestation checks. Follow-up verification run 30578823485 succeeded.",
+        "status": "done",
         "priority": "high",
         "dependencies": ["1.2", "1.3"],
         "testStrategy": "v1.1.0 release exists with all six images pullable at the tag, manifest lists sha256 digests matching GHCR, and verify workflow is green."
@@ -103,8 +103,8 @@
         "id": "1.5",
         "title": "SBOM generation and image signing in public CI",
         "description": "Add Syft SBOMs and Cosign signatures for all six public images.",
-        "details": "REQUIRED BEFORE v1.1.0 GitHub Release publication (parallel with 1.4 release-train wiring; no dependency cycle). Implement in publish-release-image-tags.yml after write-once retags and public smoke: resolve linux/amd64 + linux/arm64 child digests from each inventory OCI index and generate 12 Syft CycloneDX assets (sbom-<component>-<tag>-linux-amd64|arm64.cdx.json); Cosign keyless sign+verify all six inventory index digests via GitHub Actions OIDC with canonical identity https://github.com/SiriusScan/Sirius/.github/workflows/publish-release-image-tags.yml@refs/heads/main (workflow fail-closed to SiriusScan/Sirius@refs/heads/main); re-verify Cosign in publish-github-release before draft=false (packages:read, no id-token). Pin Syft/Cosign via checksummed install script. Contract tests in scripts/test-release-signing-contract.sh. Do not mark done until a real release run proves signatures and the 12 SBOM assets.",
-        "status": "in_progress",
+        "details": "Proven by v1.1.0 publish run 30578119633: generated and validated 12 platform-scoped Syft CycloneDX assets from exact linux/amd64 and linux/arm64 child digests; keyless-signed and verified all six inventory OCI index digests with the canonical SiriusScan/Sirius@main OIDC identity; re-verified signatures before draft=false. All 12 SBOMs and core-manifest.yaml are published release assets.",
+        "status": "done",
         "priority": "high",
         "dependencies": ["1.2", "1.3"],
         "testStrategy": "bash scripts/test-core-manifest.sh (includes signing contract); on a real release: cosign verify succeeds for all six inventory digest refs with the canonical OIDC identity; twelve platform-scoped CycloneDX SBOM assets present on the GitHub Release."


### PR DESCRIPTION
## Summary
- record the successful v1.1.0 release, exact source commit, publish run, and verification evidence
- mark Public-Core Hardening tasks 1.4/1.5 and Phase 1 complete
- advance the durable bifurcation program to the Stage 3 private-infrastructure human gate

## Test plan
- [x] `jq empty tasks/pro-bifurcation.json`
- [x] `agent-base validate evaluation programs/bifurcation/evaluations/bifurcation.s2.t005.md`
- [x] documentation/index/Compose pre-commit checks
- [ ] GitHub Actions checks pass