### PR TITLE
fix(ci): validate PEM key structure

### DIFF
--- a/scripts/community-independence/scan_text.py
+++ b/scripts/community-independence/scan_text.py
@@ -12,6 +12,8 @@ are never allowlisted.
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
 import os
 import re
 import sys
@@ -85,14 +87,51 @@ def forbidden_markers() -> List[Tuple[str, str, str]]:
         ("secret", "re:github_server_token", r"\bghs_[A-Za-z0-9]{20,}\b"),
         ("secret", "re:github_refresh", r"\bghr_[A-Za-z0-9]{20,}\b"),
         ("secret", "re:aws_access_key", r"\bAKIA[0-9A-Z]{16}\b"),
-        (
-            "secret",
-            "re:pem_private_key",
-            r"-----BEGIN (?:RSA |DSA |EC |OPENSSH |ENCRYPTED )?PRIVATE KEY-----"
-            r"[\r\n]+[A-Za-z0-9+/=\r\n]{64,}"
-            r"-----END (?:RSA |DSA |EC |OPENSSH |ENCRYPTED )?PRIVATE KEY-----",
-        ),
     ]
+
+
+PEM_PRIVATE_KEY_RE = re.compile(
+    rb"-----BEGIN (?P<label>(?:RSA |DSA |EC |OPENSSH |ENCRYPTED )?)PRIVATE KEY-----"
+    rb"\r?\n(?P<body>(?:[A-Za-z0-9+/=]{4,128}\r?\n)+)"
+    rb"-----END (?P=label)PRIVATE KEY-----"
+)
+
+
+def is_der_sequence(data: bytes) -> bool:
+    """Validate the outer definite-length DER SEQUENCE used by private-key formats."""
+    if len(data) < 2 or data[0] != 0x30:
+        return False
+    length_byte = data[1]
+    if length_byte < 0x80:
+        header_size = 2
+        content_size = length_byte
+    else:
+        length_bytes = length_byte & 0x7F
+        if length_bytes == 0 or length_bytes > 4 or len(data) < 2 + length_bytes:
+            return False
+        header_size = 2 + length_bytes
+        content_size = int.from_bytes(data[2:header_size], "big")
+    return header_size + content_size == len(data)
+
+
+def contains_private_key_pem(data: bytes) -> bool:
+    """Return true only for a complete, structurally plausible private-key PEM."""
+    for match in PEM_PRIVATE_KEY_RE.finditer(data):
+        encoded = re.sub(rb"\s+", b"", match.group("body"))
+        try:
+            decoded = base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError):
+            continue
+        if len(decoded) < 64:
+            continue
+        label = match.group("label")
+        if label == b"OPENSSH ":
+            if decoded.startswith(b"openssh-key-v1\x00"):
+                return True
+        elif is_der_sequence(decoded):
+            # RSA/DSA/EC, PKCS#8, and encrypted PKCS#8 are DER SEQUENCE values.
+            return True
+    return False
 
 
 def load_allowlist(path: Path) -> List[str]:
@@ -247,6 +286,8 @@ def match_rules(
                 findings.append(f"{rel_path}: forbidden marker [{rule.rule_id}]")
         elif rule.regex is not None and rule.regex.search(as_text):
             findings.append(f"{rel_path}: forbidden marker [{rule.rule_id}]")
+    if contains_private_key_pem(data):
+        findings.append(f"{rel_path}: forbidden marker [pem_private_key]")
     return findings
 
 

--- a/scripts/test-community-independence.sh
+++ b/scripts/test-community-independence.sh
@@ -26,7 +26,12 @@ PRO_CANARY="SIRIUS_PRO_""PRIVATE_RUNTIME_CANARY_V1"
 FAKE_PAT="ghp_""$(printf 'a%.0s' {1..36})"
 FAKE_PEM_HEADER="-----BEGIN ""RSA PRIVATE KEY-----"
 FAKE_PEM_FOOTER="-----END ""RSA PRIVATE KEY-----"
-FAKE_PEM_BODY="$(printf 'A%.0s' {1..80})"
+FAKE_PEM_BODY="$(python3 - <<'PY'
+import base64
+import textwrap
+print("\n".join(textwrap.wrap(base64.b64encode(b"\x30\x64" + b"A" * 100).decode(), 64)))
+PY
+)"
 
 cd "${PROJECT_ROOT}"
 
@@ -174,6 +179,11 @@ printf 'const marker = %q\n' "${FAKE_PEM_HEADER}" > "${TMP_DIR}/crypto-api.js"
 python3 "${CI_DIR}/scan_text.py" --root "${TMP_DIR}" --allowlist "${TMP_DIR}/allow.txt" \
   --paths-file <(printf '%s\n' "crypto-api.js") \
   || fail "a PEM header string without key material must not be treated as a key"
+printf '%s\n%s\n%s\n' "${FAKE_PEM_HEADER}" "$(printf 'A%.0s' {1..80})" "${FAKE_PEM_FOOTER}" \
+  > "${TMP_DIR}/pem-parser-fixture.txt"
+python3 "${CI_DIR}/scan_text.py" --root "${TMP_DIR}" --allowlist "${TMP_DIR}/allow.txt" \
+  --paths-file <(printf '%s\n' "pem-parser-fixture.txt") \
+  || fail "PEM-shaped parser/test text without a private-key structure must pass"
 printf '%s\n%s\n%s\n' "${FAKE_PEM_HEADER}" "${FAKE_PEM_BODY}" "${FAKE_PEM_FOOTER}" \
   > "${TMP_DIR}/actual-private-key.pem"
 if python3 "${CI_DIR}/scan_text.py" --root "${TMP_DIR}" --allowlist "${TMP_DIR}/allow.txt" \


### PR DESCRIPTION
## Summary
- base64-decode complete private-key PEM blocks before reporting them
- require valid DER SEQUENCE framing or the OpenSSH private-key magic header
- avoid package-library parser/test-string false positives while retaining real key detection

## Test plan
- [x] `bash scripts/test-community-independence.sh`
- [x] parser/header-only and invalid-structure PEM fixtures pass
- [x] structurally valid generated DER private-key fixture fails
- [x] archive/image scanner canaries pass
- [ ] PR checks pass
- [ ] main workflow completes all 12 image scans and Compose smoke

Fixes the GnuTLS parser-string false positive in main run 30601820946.