### PR TITLE
fix(ci): distinguish public system key fixtures

### DIFF
--- a/documentation/dev/deployment/README.community-independence.md
+++ b/documentation/dev/deployment/README.community-independence.md
@@ -109,6 +109,9 @@ registry logins, organization secrets, or PATs.
 - Recognized nested gzip/zip/tar payloads are inspected with bounded depth/size; encrypted
   or opaque blobs may still hide markers
 - High-confidence credential regexes are intentionally narrow to limit false positives
+- PEM findings require a complete, decodable private-key structure. Public package test
+  keys embedded in compiled shared libraries under system `lib`/`usr/lib` paths are
+  ignored; application paths and key files remain fail-closed.
 - Full image scan requires Docker/buildx and network; local mocked contract tests cover
   index resolution and 12 child pull/scan wiring when Docker is unavailable
 - Compose smoke requires a working Docker engine and network access to public GHCR

--- a/scripts/community-independence/nested_content.py
+++ b/scripts/community-independence/nested_content.py
@@ -17,7 +17,8 @@ Budget model (shared across a top-level scan root)
   are found) but does not double/triple-count when a nested parse succeeds.
 
 Caps: traversal/link rejection, per-member buffering threshold, nest depth,
-member count, and a GiB-level total uncompressed scan budget.
+archive-entry count (including files, directories, and links to prevent metadata
+bombs), and a GiB-level total uncompressed scan budget.
 
 Link policy
 -----------
@@ -273,6 +274,11 @@ def _raw_findings_bytes(
     return scan_text.match_rules(data, rel_path, rules, allowlist)
 
 
+def _without_container_pem(findings: Sequence[str]) -> List[str]:
+    """Drop only pathless raw-container PEM hits after member parsing succeeds."""
+    return [item for item in findings if "[pem_private_key]" not in item]
+
+
 def _scan_tar_stream(
     fh: BinaryIO,
     rel_path: str,
@@ -290,6 +296,15 @@ def _scan_tar_stream(
     try:
         with tarfile.open(fileobj=fh, mode=mode) as tf:
             for member in tf:
+                _validate_member_name(member.name)
+                nested_rel = f"{rel_path}#tar/{scan_text.norm_rel(member.name)}"
+                budget.add_member(nested_rel)
+                metadata = f"{member.name}\n{member.linkname or ''}".encode(
+                    "utf-8", errors="surrogateescape"
+                )
+                findings.extend(
+                    scan_text.match_rules(metadata, f"{nested_rel}#metadata", rules, allowlist)
+                )
                 if member.issym() or member.islnk():
                     # Image layers: never extract/follow links; ignore entries even
                     # when the in-container target is absolute (BusyBox style).
@@ -299,9 +314,6 @@ def _scan_tar_stream(
                     _reject_link(member)
                 if not member.isfile():
                     continue
-                _validate_member_name(member.name)
-                nested_rel = f"{rel_path}#tar/{scan_text.norm_rel(member.name)}"
-                budget.add_member(nested_rel)
 
                 extracted = tf.extractfile(member)
                 if extracted is None:
@@ -635,7 +647,8 @@ def scan_nested_bytes(
         budget.add_bytes(len(data), rel_path)
         return findings
 
-    findings.extend(nested_findings)
+    if nested_ok:
+        return _without_container_pem(findings) + nested_findings
     if not nested_ok:
         # Opaque: charge this representation once.
         budget.add_bytes(len(data), rel_path)
@@ -725,7 +738,10 @@ def scan_nested_fileobj(
             )
         return findings
 
-    findings.extend(nested_findings)
+    if nested_ok:
+        # Keep raw non-PEM findings for trailing/polyglot bytes. PEM decisions use
+        # precise member paths so public system-library fixtures can be distinguished.
+        return _without_container_pem(findings) + nested_findings
     if not nested_ok:
         if raw_size >= 0:
             budget.add_bytes(raw_size, rel_path)

--- a/scripts/community-independence/scan_text.py
+++ b/scripts/community-independence/scan_text.py
@@ -134,6 +134,17 @@ def contains_private_key_pem(data: bytes) -> bool:
     return False
 
 
+def is_system_shared_library(rel_path: str) -> bool:
+    """Identify public distro shared libraries that may embed non-secret test keys."""
+    rel = norm_rel(rel_path)
+    inner = re.split(r"#(?:tar|zip|gzip)/", rel)[-1]
+    system_prefixes = ("lib/", "lib64/", "usr/lib/", "usr/lib64/")
+    if not inner.startswith(system_prefixes):
+        return False
+    name = PurePosixPath(inner).name
+    return name.endswith(".so") or re.search(r"\.so(?:\.\d+)+$", name) is not None
+
+
 def load_allowlist(path: Path) -> List[str]:
     if not path.is_file():
         raise SystemExit(f"allowlist not found: {path}")
@@ -286,7 +297,7 @@ def match_rules(
                 findings.append(f"{rel_path}: forbidden marker [{rule.rule_id}]")
         elif rule.regex is not None and rule.regex.search(as_text):
             findings.append(f"{rel_path}: forbidden marker [{rule.rule_id}]")
-    if contains_private_key_pem(data):
+    if contains_private_key_pem(data) and not is_system_shared_library(rel_path):
         findings.append(f"{rel_path}: forbidden marker [pem_private_key]")
     return findings
 

--- a/scripts/test-community-independence.sh
+++ b/scripts/test-community-independence.sh
@@ -190,6 +190,27 @@ if python3 "${CI_DIR}/scan_text.py" --root "${TMP_DIR}" --allowlist "${TMP_DIR}/
   --paths-file <(printf '%s\n' "actual-private-key.pem") 2>/dev/null; then
   fail "a complete PEM private-key block must be rejected"
 fi
+mkdir -p "${TMP_DIR}/usr/lib/x86_64-linux-gnu" "${TMP_DIR}/app"
+cp "${TMP_DIR}/actual-private-key.pem" \
+  "${TMP_DIR}/usr/lib/x86_64-linux-gnu/libpublic-fixture.so.1"
+python3 "${CI_DIR}/scan_text.py" --root "${TMP_DIR}" --allowlist "${TMP_DIR}/allow.txt" \
+  --paths-file <(printf '%s\n' "usr/lib/x86_64-linux-gnu/libpublic-fixture.so.1") \
+  || fail "a public distro shared-library fixture must not be treated as a Sirius key"
+cp "${TMP_DIR}/actual-private-key.pem" "${TMP_DIR}/app/libprivate.so"
+if python3 "${CI_DIR}/scan_text.py" --root "${TMP_DIR}" --allowlist "${TMP_DIR}/allow.txt" \
+  --paths-file <(printf '%s\n' "app/libprivate.so") 2>/dev/null; then
+  fail "the shared-library exception must not apply to application paths"
+fi
+cp "${TMP_DIR}/actual-private-key.pem" "${TMP_DIR}/usr/lib/leaked.key"
+if python3 "${CI_DIR}/scan_text.py" --root "${TMP_DIR}" --allowlist "${TMP_DIR}/allow.txt" \
+  --paths-file <(printf '%s\n' "usr/lib/leaked.key") 2>/dev/null; then
+  fail "the shared-library exception must not apply to key files"
+fi
+cp "${TMP_DIR}/actual-private-key.pem" "${TMP_DIR}/usr/lib/leaked.so.pem"
+if python3 "${CI_DIR}/scan_text.py" --root "${TMP_DIR}" --allowlist "${TMP_DIR}/allow.txt" \
+  --paths-file <(printf '%s\n' "usr/lib/leaked.so.pem") 2>/dev/null; then
+  fail "the shared-library exception must require a real soname"
+fi
 pass "PEM key-material detection"
 
 echo "==> canary: private registry/module/pro canary rejected"
@@ -535,7 +556,7 @@ pass "SBOM wrong-component + duplicate digest canaries"
 
 echo "==> canary: docker-save fixtures via scan_image_layers.py"
 python3 - <<PY
-import gzip, io, json, tarfile, sys
+import base64, gzip, io, json, tarfile, sys, zipfile
 from pathlib import Path
 sys.path.insert(0, "scripts/community-independence")
 import scan_image_layers
@@ -566,6 +587,61 @@ write_save(clean, [("manifest.json", b"[]"), ("config.json", cfg), ("layer.tar",
 findings = scan_image_layers.scan_docker_save(clean, allow, "sirius-ui/linux-amd64")
 assert findings == [], findings
 
+# Public package key fixture in a system shared library is ignored by precise path.
+der = b"\x30\x64" + b"A" * 100
+encoded = base64.b64encode(der)
+pem_body = b"\n".join(encoded[i:i + 64] for i in range(0, len(encoded), 64))
+pem = b"-----BEGIN RSA PRIVATE KEY-----\n" + pem_body + b"\n-----END RSA PRIVATE KEY-----\n"
+system_fixture = tmp / "system-fixture.tar"
+lbuf = io.BytesIO()
+with tarfile.open(fileobj=lbuf, mode="w") as lf:
+    info = tarfile.TarInfo("usr/lib/x86_64-linux-gnu/libfixture.so.1")
+    info.size = len(pem)
+    lf.addfile(info, io.BytesIO(pem))
+write_save(system_fixture, [("layer.tar", lbuf.getvalue())])
+findings = scan_image_layers.scan_docker_save(
+    system_fixture, allow, "sirius-engine/linux-amd64"
+)
+assert findings == [], findings
+
+# Small nested zip uses the bytes path and keeps the same precise exception.
+zip_buf = io.BytesIO()
+with zipfile.ZipFile(zip_buf, "w") as zf:
+    zf.writestr("usr/lib/libfixture.so.2", pem)
+zip_fixture = tmp / "system-fixture-zip.tar"
+lbuf = io.BytesIO()
+with tarfile.open(fileobj=lbuf, mode="w") as lf:
+    payload = zip_buf.getvalue()
+    info = tarfile.TarInfo("opt/package.zip")
+    info.size = len(payload)
+    lf.addfile(info, io.BytesIO(payload))
+write_save(zip_fixture, [("layer.tar", lbuf.getvalue())])
+findings = scan_image_layers.scan_docker_save(
+    zip_fixture, allow, "sirius-engine/linux-amd64"
+)
+assert findings == [], findings
+
+# The same key in an application path remains a finding.
+app_fixture = tmp / "app-fixture.tar"
+lbuf = io.BytesIO()
+with tarfile.open(fileobj=lbuf, mode="w") as lf:
+    info = tarfile.TarInfo("app/libfixture.so")
+    info.size = len(pem)
+    lf.addfile(info, io.BytesIO(pem))
+write_save(app_fixture, [("layer.tar", lbuf.getvalue())])
+findings = scan_image_layers.scan_docker_save(
+    app_fixture, allow, "sirius-engine/linux-amd64"
+)
+assert any("[pem_private_key]" in item for item in findings), findings
+
+# Successful tar parsing must retain non-PEM findings in trailing/polyglot bytes.
+trailing_fixture = tmp / "trailing-marker.tar"
+write_save(trailing_fixture, [("layer.tar", layer_buf.getvalue() + marker)])
+findings = scan_image_layers.scan_docker_save(
+    trailing_fixture, allow, "sirius-ui/linux-amd64"
+)
+assert any("[private_registry]" in item for item in findings), findings
+
 # poisoned config
 poison_cfg = tmp / "poison-config.tar"
 write_save(poison_cfg, [("config.json", b'{"Env":["X=' + marker + b'"]}')])
@@ -583,6 +659,18 @@ with tarfile.open(fileobj=lbuf, mode="w") as lf:
 write_save(poison_layer, [("layer.tar", lbuf.getvalue())])
 findings = scan_image_layers.scan_docker_save(poison_layer, allow, "sirius-api/linux-arm64")
 assert findings, "expected poisoned layer findings"
+
+# Private markers in member names remain visible after raw tar findings are discarded.
+poison_name = tmp / "poison-name.tar"
+lbuf = io.BytesIO()
+with tarfile.open(fileobj=lbuf, mode="w") as lf:
+    data = b"clean\n"
+    info = tarfile.TarInfo("app/" + marker.decode() + "/payload")
+    info.size = len(data)
+    lf.addfile(info, io.BytesIO(data))
+write_save(poison_name, [("layer.tar", lbuf.getvalue())])
+findings = scan_image_layers.scan_docker_save(poison_name, allow, "sirius-api/linux-amd64")
+assert any("#metadata" in item for item in findings), findings
 
 # nested compressed marker inside layer
 nested = tmp / "nested-layer.tar"


### PR DESCRIPTION
## Summary
- keep raw non-PEM polyglot findings while using precise archive-member paths for PEM decisions
- ignore structurally valid public test keys only in real system shared-library sonames
- retain key detection in app paths, key files, opaque blobs, and non-soname files
- scan tar member/link metadata and count every archive entry against metadata-bomb limits

## Test plan
- [x] `bash scripts/test-community-independence.sh`
- [x] `bash scripts/test-core-manifest.sh`
- [x] system `.so` and nested-zip fixtures pass
- [x] app, key, `.so.pem`, member-name, and trailing-polyglot canaries fail as expected
- [x] independent re-review: no findings
- [ ] PR checks pass
- [ ] main workflow completes all 12 image scans and Compose smoke

Fixes the public GnuTLS fixture finding in main run 30602891339.