### PR TITLE
docs: class-ready cut is private Pro compose root

### DIFF
--- a/programs/bifurcation/PROGRAM.md
+++ b/programs/bifurcation/PROGRAM.md
@@ -72,6 +72,15 @@ Dependencies and order:
 6. Phase 5 Enterprise Reporting; depends on Phase 4.
 7. Phase 6 compatibility, promotion, cleanup, and reconciliation; depends on Phase 5.
 
+Accelerated class-ready track (parallel, not a replacement):
+
+- API Module and OpenAPI are sufficient to start a private companion Pro-dev
+  API/UI/worker composition for class use.
+- Phase 3.3-3.6 and Phases 4-6 remain required for the integrated Pro product, but do
+  not block the explicitly non-production companion cut.
+- The class cut, stub boundary, commands, and human gates are recorded in
+  `programs/complete-split-deploy-to-range/CLASS_READY_CUT.md`.
+
 Ownership:
 
 - Each bounded task records exclusive writable paths before execution.
@@ -262,7 +271,8 @@ status: active
 verdict: accepted
 artifact_verdict: accepted
 loop_decision: continue
-next_action: Implement task 3.3, the versioned public event envelope and additive queue compatibility contract.
+execution_priority: deferred-for-class-ready-cut
+next_action: Resume task 3.3 after the class-ready Pro-dev demonstration, or earlier only if the companion implementation finds a concrete event-contract blocker.
 ```
 
 ## Stage 3: Private Supply Chain
@@ -577,6 +587,33 @@ Current task:
   - JSON schema validation and negative fixtures
   - Existing Community queue regression tests
 - `next_action`: Inventory existing queue payloads and implement task 3.3.
+
+Execution priority is temporarily deferred by the operator's class-readiness
+directive. The task, criteria, full Phase 3 exit criterion, and original acceptance
+criteria remain intact.
+
+## Parallel Stage CR: Class-ready Pro-dev Cut
+
+This stage accelerates a class demonstration; it does not complete Phase 3, Phase 4,
+Phase 5, Phase 6, or the full bifurcation acceptance criteria.
+
+Tasks:
+
+- [x] Inspect the private repositories, Phase 5 overlay contract, immutable Community
+  lock, current Community deployment evidence, and range access path
+- [x] Select a companion Pro-dev API/UI/worker cut with explicit dev-only
+  entitlements and no Pro migrations
+- [ ] Implement the private images and `docker-compose.community-lock.yaml` plus
+  `docker-compose.pro-dev.yaml` in `OpenSecurity-Infosec/sirius-pro`
+- [ ] Publish tested private images by digest after separate human approval
+- [ ] Back up, deploy, verify instructor paths, and prove Community-only rollback on
+  VMID 220 after separate range-owner approval
+
+Class-ready scope and handoff:
+`programs/complete-split-deploy-to-range/CLASS_READY_CUT.md`.
+
+Planning/discovery evidence:
+`programs/complete-split-deploy-to-range/evaluations/complete-split-deploy-to-range.scr.t001.md`.
 
 ## Stage 5: Entitlements and First Vertical
 

--- a/programs/complete-split-deploy-to-range/CLASS_READY_CUT.md
+++ b/programs/complete-split-deploy-to-range/CLASS_READY_CUT.md
@@ -1,0 +1,300 @@
+# Class-ready Pro-dev cut
+
+Date: 2026-07-31
+
+This is an accelerated, non-production track inside the existing bifurcation
+program. It does not replace or weaken the full Community/Pro acceptance criteria.
+It produces a visibly distinct Pro-dev composition for class use while the complete
+contract, entitlement, Reporting, and release tracks continue separately.
+
+## Decision
+
+Build a private companion stack in the existing private `sirius-pro` repository and
+add it to the Community Compose project:
+
+| Layer | Class-ready implementation | Boundary |
+| --- | --- | --- |
+| Community core | All six Community `v1.1.0` images from `core.lock.yaml`, overridden by exact `@sha256:` references | No private credentials, packages, or source required to run Community alone |
+| Pro-dev API | Private Go/Fiber image with `/health`, `/api/pro/v1/status`, and a deterministic stub `/api/pro/v1/reports` route | Companion service; does not replace or import the Community API |
+| Pro-dev UI | Private Next.js image on `:3100` with a prominent `PRO DEV / NON-PRODUCTION` banner, Pro status/report stub, and link to Community UI on `:3000` | Companion service until the public UI registry is ready |
+| Pro-dev worker | Private Go image with a health endpoint on `:9102` and explicit idle/stub state | Does not consume Community queues until the event contract is ready |
+| Entitlement | Fail closed by default; class deployment explicitly sets a dev-only allow-all provider and surfaces that mode in API/UI | No customer license, issuer, signing key, or claim of production licensing |
+| Data | Read-only/no-op Pro stubs; no Pro schema or migration | Community volumes and scan data remain the rollback authority |
+
+The private deployment directory should contain:
+
+- `docker-compose.community-lock.yaml`: overrides `sirius-ui`, `sirius-api`,
+  `sirius-migrate`, `sirius-engine`, `sirius-postgres`, `sirius-rabbitmq`, and
+  `sirius-valkey` with the existing locked Community digests.
+- `docker-compose.pro-dev.yaml`: adds `sirius-pro-api`, `sirius-pro-ui`, and
+  `sirius-pro-worker`; every private image variable must contain `@sha256:`.
+- `pro-dev.lock.yaml`: records the three tested private image digests and source
+  commit. It is a class artifact, not a Pro release manifest.
+- A validator that rejects mutable image references, a missing explicit dev-mode
+  acknowledgement, or any attempt to add a Pro dependency to Community.
+
+This companion shape deliberately avoids the unfinished public event, UI registry,
+and engine contracts. Those contracts are blockers for the integrated product, not
+for this class-only composition.
+
+## Scope split
+
+### A. Must ship for the class demo
+
+- The locked Community `v1.1.0` six-image stack remains healthy on `:3000` and
+  `:9001/health`.
+- Three private Pro-dev images build, pass native tests, publish privately, and are
+  consumed by digest.
+- Pro-dev UI is visibly distinct on `:3100`; Pro-dev API and worker health checks are
+  green.
+- `/api/pro/v1/reports` is capability checked. With no provider it returns the
+  structured `CAPABILITY_NOT_LICENSED` response; the class Compose file explicitly
+  enables and labels `dev_allow_all`.
+- The overlay adds no Pro migrations and can be removed while Community
+  health and existing scan data remain intact.
+- A pre-change database backup and the previous Community checkout/image state are
+  recorded before the range change.
+
+### B. May ship stubbed/dev
+
+- Entitlements: explicit allow-all development provider; no signed license.
+- Reporting: status/list/generate-demo response only; no PDF, CSV, scheduler,
+  delivery, or report persistence.
+- Worker: healthy idle/no-op loop; no queue consumption or audit-event production.
+- UI: companion page instead of an integrated Community navigation entry.
+- Pro API: companion service instead of a compile-time replacement build.
+
+Every stub must be labeled `non-production`, return its current mode, and have a
+test proving that the default configuration fails closed. The two required class
+acknowledgements are `SIRIUS_PRO_DEV_ALLOW_ALL=true` and
+`SIRIUS_PRO_DEV_ACKNOWLEDGE_NON_PRODUCTION=true`; the overlay validator must reject
+missing or false values.
+
+### C. Deferred to the full program
+
+- Public event envelope, UI registry, engine interfaces, and full compatibility
+  harness (Phase 3.3-3.6).
+- Capability catalog integration, signed offline licenses, KMS/key rotation, grace,
+  renewal, and lifecycle matrices (Phase 4).
+- Pro schema, migrations, real event consumption, scheduling, PDF/CSV output, audit
+  history, and integrated Reporting UI/API/worker (Phase 5).
+- Nightly compatibility, full SBOM/provenance/signing promotion, release manifests,
+  and promotion-by-retag (Phase 6).
+- Counsel, EULA/customer distribution, customer licenses, production deployment,
+  and any external release claim.
+
+## Evidence and blockers at cut selection
+
+- `sirius-pro` is a skeleton at commit `16d483e`: no Compose file, Dockerfile, Go
+  module, UI package, or worker exists yet.
+- `sirius-entitlements` is a skeleton at commit `ff1e4e2`.
+- `sirius-release` has the private supply-chain bootstrap at commit `c7bbdc6`, but no
+  product image pipeline has been instantiated.
+- `sirius-pro/core.lock.yaml` already pins Community `v1.1.0` source commit
+  `b61b47b468cfc5c837a5bde50eeafe52df4fe10d` and all six release digests.
+- Community main is `a279198a3`; its API Module/OpenAPI contracts are green, but it is
+  not the immutable six-image class input. Use the `v1.1.0` lock for this cut.
+- The last independent range receipt (2026-07-31) says VMID 220 was started and
+  Community UI/API returned 200. The installed checkout was previously recorded as
+  `/home/agi/Sirius` using mutable `latest`; live state must be re-read before change.
+- This agent sandbox rejects all network sockets with `Operation not permitted`, so
+  it cannot re-verify the range or use the jump host. That is an execution-environment
+  restriction, not evidence that VMID 220 is down.
+- The private repositories are outside this run's writable workspace. Private source
+  must not be staged in the public Sirius checkout as a workaround.
+- This managed workspace also exposes the public repository's `.git` directory as
+  read-only. The scoped documentation changes are present in the working tree, but
+  `git add` fails while creating `.git/index.lock`; a later writable run must commit
+  them before private implementation starts.
+- Private Pro-dev image digests and a least-privilege GHCR pull credential for the
+  range do not yet exist.
+
+No additional public contract is a blocker for the companion cut. The real blockers
+are private implementation, private image publication, GHCR read access on the guest,
+and a network-capable operator session for the approved deployment gate.
+
+## Ordered execution checklist
+
+### 1. Implement and validate the private cut — agent
+
+Run the next agent cycle with
+`/Users/oz/Projects/Sirius-Project/private/sirius-pro` as a writable workspace. Own
+only that repository. Add the three services and deployment files described above.
+
+Required validation after the files exist:
+
+```bash
+cd /Users/oz/Projects/Sirius-Project/private/sirius-pro
+make test
+(cd apps/api && go test ./...)
+(cd apps/worker && go test ./...)
+npm --prefix apps/ui ci
+npm --prefix apps/ui run lint
+npm --prefix apps/ui run build
+bash scripts/validate-pro-dev-compose.sh
+git diff --check
+```
+
+The validation script must render the Community base + production override + both
+private overlays with fixture-only values, list all ten rendered image references,
+and reject any reference that lacks `@sha256:`. Commit locally; do not push.
+
+### 2. Review, publish, and record private images — human gates
+
+1. Human reviews the local private diff and explicitly approves push/PR/merge.
+2. Human separately approves the private image workflow dispatch.
+3. The workflow builds each image once from the accepted full source SHA, tests it,
+   pushes a source-SHA tag, resolves the three digests, and writes the values used for
+   `pro-dev.lock.yaml`. This class cut does not claim the deferred Phase 6 promotion
+   guarantees.
+4. Human provisions a least-privilege `read:packages` credential to the range guest.
+   Do not commit it or copy it into Compose/YAML.
+
+Planned dispatch shape after the private workflow exists:
+
+```bash
+gh workflow run pro-dev-images.yml \
+  --repo "$SIRIUS_PRO_REPOSITORY" \
+  -f source_sha=<accepted-full-40-character-sha>
+```
+
+### 3. Re-enter the range read-only — human/operator
+
+The previously proven access path is:
+
+```bash
+ssh -i ~/.ssh/dev01_agi -o BatchMode=yes \
+  -o ProxyCommand="ssh -i ~/.ssh/dev01_agi -o BatchMode=yes -W %h:%p agi@192.168.123.200" \
+  agi@10.0.10.20
+```
+
+Before approval to change anything, collect:
+
+```bash
+cd /home/agi/Sirius
+git status --short --branch
+git rev-parse HEAD
+docker compose ps
+docker ps --format '{{.Names}} {{.Image}} {{.Status}}'
+curl -fsS http://127.0.0.1:9001/health
+curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/
+```
+
+If this path fails, stop and report whether the failure is jump-host SSH, guest SSH,
+VM power, or guest service health. Do not add routes, firewall rules, or restart VMID
+220 without a separate range-owner approval.
+
+### 4. Back up and stage — human deployment gate
+
+After range-owner approval, preserve the existing state without exposing secrets:
+
+```bash
+install -d -m 700 /home/agi/backups
+cd /home/agi/Sirius
+git rev-parse HEAD > /home/agi/backups/sirius-pre-pro-dev.git-sha
+docker ps --no-trunc --format '{{.Names}} {{.Image}} {{.Status}}' \
+  > /home/agi/backups/sirius-pre-pro-dev.containers.txt
+docker exec sirius-postgres sh -lc \
+  'pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Fc' \
+  > /home/agi/backups/sirius-pre-pro-dev.dump
+test -s /home/agi/backups/sirius-pre-pro-dev.dump
+```
+
+The operator copies the reviewed private `deployments/` artifacts to
+`/home/agi/sirius-pro/deployments/`, confirms `/home/agi/Sirius` has no tracked local
+changes, fetches the public `v1.1.0` tag, and moves the public checkout to that exact
+tag. Existing ignored `.env` and secret files remain Vault-derived runtime mirrors.
+
+```bash
+cd /home/agi/Sirius
+test -z "$(git status --porcelain --untracked-files=no)"
+git fetch --tags origin v1.1.0
+git checkout --detach v1.1.0
+test "$(git rev-parse HEAD)" = b61b47b468cfc5c837a5bde50eeafe52df4fe10d
+```
+
+The `v1.1.0` Community core migrator may apply core migrations on first start. The
+class cut adds no Pro migration; the backup remains mandatory for the core change.
+
+Log in to GHCR only via standard input from the human-provided ephemeral environment:
+
+```bash
+printf '%s' "$SIRIUS_PRO_GHCR_PULL_TOKEN" | \
+  docker login ghcr.io --username "$SIRIUS_PRO_GHCR_USER" --password-stdin
+unset SIRIUS_PRO_GHCR_PULL_TOKEN
+```
+
+### 5. Render, deploy, and verify — agent observes; human executes
+
+Use the existing Compose project name so named Community volumes are reused:
+
+```bash
+cd /home/agi/Sirius
+docker compose --env-file /home/agi/Sirius/.env \
+  --project-directory /home/agi/Sirius -p sirius \
+  -f /home/agi/Sirius/docker-compose.yaml \
+  -f /home/agi/Sirius/docker-compose.prod.yaml \
+  -f /home/agi/sirius-pro/deployments/docker-compose.community-lock.yaml \
+  -f /home/agi/sirius-pro/deployments/docker-compose.pro-dev.yaml \
+  config --images
+
+docker compose --env-file /home/agi/Sirius/.env \
+  --project-directory /home/agi/Sirius -p sirius \
+  -f /home/agi/Sirius/docker-compose.yaml \
+  -f /home/agi/Sirius/docker-compose.prod.yaml \
+  -f /home/agi/sirius-pro/deployments/docker-compose.community-lock.yaml \
+  -f /home/agi/sirius-pro/deployments/docker-compose.pro-dev.yaml \
+  pull
+
+docker compose --env-file /home/agi/Sirius/.env \
+  --project-directory /home/agi/Sirius -p sirius \
+  -f /home/agi/Sirius/docker-compose.yaml \
+  -f /home/agi/Sirius/docker-compose.prod.yaml \
+  -f /home/agi/sirius-pro/deployments/docker-compose.community-lock.yaml \
+  -f /home/agi/sirius-pro/deployments/docker-compose.pro-dev.yaml \
+  up -d
+```
+
+Acceptance probes:
+
+```bash
+curl -fsS http://127.0.0.1:9001/health
+curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/
+curl -fsS http://127.0.0.1:9101/health
+curl -fsS http://127.0.0.1:9101/api/pro/v1/status
+curl -fsS http://127.0.0.1:9101/api/pro/v1/reports
+curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3100/
+curl -fsS http://127.0.0.1:9102/health
+```
+
+The status/report responses must explicitly identify `pro-dev`,
+`entitlement_mode=dev_allow_all`, and stub limitations. The instructor then verifies
+the Community scan path and the Pro-dev page from the approved client path.
+
+### 6. Prove Community-only rollback — human deployment gate
+
+Do not use `down --volumes` or delete any volume. Reconcile the project without the
+Pro-dev overlay:
+
+```bash
+cd /home/agi/Sirius
+docker compose --env-file /home/agi/Sirius/.env \
+  --project-directory /home/agi/Sirius -p sirius \
+  -f /home/agi/Sirius/docker-compose.yaml \
+  -f /home/agi/Sirius/docker-compose.prod.yaml \
+  -f /home/agi/sirius-pro/deployments/docker-compose.community-lock.yaml \
+  up -d --remove-orphans
+curl -fsS http://127.0.0.1:9001/health
+curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/
+```
+
+Verify an existing scan remains readable. Restore the accepted Pro-dev overlay only
+after that evidence is captured and the human approves it.
+
+## Immediate human gate
+
+Start the next bounded agent run with this Sirius repository's `.git` metadata and
+the private `sirius-pro` repository writable. Approve local commits of this handoff
+and implementation of the three stub images plus the two deployment overlays. Do not
+approve push, publication, range mutation, or deployment yet; each remains a separate
+gate above.

--- a/programs/complete-split-deploy-to-range/CLASS_READY_CUT.md
+++ b/programs/complete-split-deploy-to-range/CLASS_READY_CUT.md
@@ -4,71 +4,92 @@ Date: 2026-07-31
 
 This is an accelerated, non-production track inside the existing bifurcation
 program. It does not replace or weaken the full Community/Pro acceptance criteria.
-It produces a visibly distinct Pro-dev composition for class use while the complete
-contract, entitlement, Reporting, and release tracks continue separately.
+It establishes a private Pro working-tree / Compose build root on the range so that
+development mutations stay in `OpenSecurity-Infosec/sirius-pro`, while Community is
+consumed only as immutable digests. Full contract, entitlement, Reporting, and
+release tracks continue separately.
 
 ## Decision
 
-Build a private companion stack in the existing private `sirius-pro` repository and
-add it to the Community Compose project:
+**Success for this cut** is that private `OpenSecurity-Infosec/sirius-pro` is the
+**sole mutable Compose and build root** on the approved range host, checked out at
+`/home/agi/sirius-pro`. Community is consumed only through `core.lock.yaml`
+immutable digests for tag `v1.1.0`. Canonical operator ports `:3000` (UI) and
+`:9001` (API) are owned by the Pro-owned Compose project. `/home/agi/Sirius` is
+retired from the development path (read-only pin of the locked Community tag, or
+unused).
+
+**Companion sidecars alone do not satisfy this cutoff.** Private services listening
+only on `:3100` / `:9101` / `:9102` while Community continues to own `:3000` /
+`:9001` from `/home/agi/Sirius` leave the range as a Community development surface
+and are insufficient, even if those sidecars are healthy.
 
 | Layer | Class-ready implementation | Boundary |
 | --- | --- | --- |
-| Community core | All six Community `v1.1.0` images from `core.lock.yaml`, overridden by exact `@sha256:` references | No private credentials, packages, or source required to run Community alone |
-| Pro-dev API | Private Go/Fiber image with `/health`, `/api/pro/v1/status`, and a deterministic stub `/api/pro/v1/reports` route | Companion service; does not replace or import the Community API |
-| Pro-dev UI | Private Next.js image on `:3100` with a prominent `PRO DEV / NON-PRODUCTION` banner, Pro status/report stub, and link to Community UI on `:3000` | Companion service until the public UI registry is ready |
-| Pro-dev worker | Private Go image with a health endpoint on `:9102` and explicit idle/stub state | Does not consume Community queues until the event contract is ready |
-| Entitlement | Fail closed by default; class deployment explicitly sets a dev-only allow-all provider and surfaces that mode in API/UI | No customer license, issuer, signing key, or claim of production licensing |
-| Data | Read-only/no-op Pro stubs; no Pro schema or migration | Community volumes and scan data remain the rollback authority |
+| Private build root | Range development and Compose project live under `/home/agi/sirius-pro` from private `sirius-pro` | Sole mutable working tree for Pro-dev on the range |
+| Community core | Six Community `v1.1.0` images from `core.lock.yaml`, referenced only by exact `@sha256:` digests | No private credentials required to run Community alone elsewhere; on the range, Pro Compose owns the project that pulls those digests |
+| Canonical ports | Pro-owned Compose project binds `:3000` and `:9001` | Operator and instructor paths stay on the existing ports |
+| `/home/agi/Sirius` | Detached read-only pin of `v1.1.0` or left unused; not the active Compose project directory | Not a development write path; no local Community forks or private Community clones |
+| Optional Pro-dev stubs | Private API/UI/worker stubs may exist, but only as overlays inside the Pro-owned project | Sidecars on `:3100`/`:9101`/`:9102` are optional and **not** the acceptance signal |
+| Shared fixes | Bugfixes that belong in Community remain public-first per ADR-001/ADR-002 | No private Community fork; no exporting private commits into public as the product model |
+| Product features | None required for this cut | No Reporting, entitlements platform, event contract, UI registry, or engine interface work |
 
-The private deployment directory should contain:
+The private repository should contain (exact layout may evolve in private work, but
+the range outcome above is fixed):
 
-- `docker-compose.community-lock.yaml`: overrides `sirius-ui`, `sirius-api`,
-  `sirius-migrate`, `sirius-engine`, `sirius-postgres`, `sirius-rabbitmq`, and
-  `sirius-valkey` with the existing locked Community digests.
-- `docker-compose.pro-dev.yaml`: adds `sirius-pro-api`, `sirius-pro-ui`, and
-  `sirius-pro-worker`; every private image variable must contain `@sha256:`.
-- `pro-dev.lock.yaml`: records the three tested private image digests and source
-  commit. It is a class artifact, not a Pro release manifest.
-- A validator that rejects mutable image references, a missing explicit dev-mode
-  acknowledgement, or any attempt to add a Pro dependency to Community.
+- `core.lock.yaml`: already pins Community `v1.1.0` source commit and six release
+  digests; remains the only Community input.
+- A Pro-owned Compose project that pulls those locked digests and owns `:3000` /
+  `:9001` (and any optional Pro-dev services).
+- A validator that rejects mutable image references for locked Community and private
+  images, and rejects treating `/home/agi/Sirius` as the active development Compose
+  root.
+- Optional class artifacts (`pro-dev.lock.yaml`, stub services) that must not redefine
+  success away from the private build-root cutoff.
 
-This companion shape deliberately avoids the unfinished public event, UI registry,
-and engine contracts. Those contracts are blockers for the integrated product, not
-for this class-only composition.
+This shape deliberately avoids unfinished public event, UI registry, engine, and
+entitlement contracts. Those remain blockers for the integrated product, not for
+establishing the private working-tree cutoff.
+
+## Non-goals
+
+- Private fork or private clone of Community as the product model.
+- Making shared Community fixes land first (or only) in private trees.
+- Shipping Enterprise Reporting, signed licenses, event contracts, UI registry,
+  engine interfaces, or other product features for this cut.
+- Claiming that healthy companion sidecars on non-canonical ports complete the cut.
+- Weakening Community independence, leakage controls, or the full program acceptance
+  criteria.
 
 ## Scope split
 
 ### A. Must ship for the class demo
 
-- The locked Community `v1.1.0` six-image stack remains healthy on `:3000` and
-  `:9001/health`.
-- Three private Pro-dev images build, pass native tests, publish privately, and are
-  consumed by digest.
-- Pro-dev UI is visibly distinct on `:3100`; Pro-dev API and worker health checks are
-  green.
-- `/api/pro/v1/reports` is capability checked. With no provider it returns the
-  structured `CAPABILITY_NOT_LICENSED` response; the class Compose file explicitly
-  enables and labels `dev_allow_all`.
-- The overlay adds no Pro migrations and can be removed while Community
-  health and existing scan data remain intact.
-- A pre-change database backup and the previous Community checkout/image state are
-  recorded before the range change.
+- Private `sirius-pro` is the sole mutable Compose/build root on the range at
+  `/home/agi/sirius-pro`.
+- Community is consumed only via `core.lock.yaml` immutable digests for `v1.1.0`
+  (source commit `b61b47b468cfc5c837a5bde50eeafe52df4fe10d` and the six locked
+  image digests).
+- The Pro-owned Compose project owns canonical ports `:3000` and `:9001`; health
+  probes against those ports succeed from the approved client path.
+- `/home/agi/Sirius` is not used as the active development Compose project
+  (read-only pin of `v1.1.0` or unused).
+- No private Community fork; public-first shared fixes per ADR-001/ADR-002 remain
+  policy.
+- Pre-change database backup and prior Community checkout/image state are recorded
+  before the range change.
+- No Pro schema/migration is required for this cut; Community volumes and scan data
+  remain the rollback authority where volumes are reused.
 
-### B. May ship stubbed/dev
+### B. May ship stubbed/dev (optional; not acceptance)
 
-- Entitlements: explicit allow-all development provider; no signed license.
-- Reporting: status/list/generate-demo response only; no PDF, CSV, scheduler,
-  delivery, or report persistence.
-- Worker: healthy idle/no-op loop; no queue consumption or audit-event production.
-- UI: companion page instead of an integrated Community navigation entry.
-- Pro API: companion service instead of a compile-time replacement build.
+- Private Pro-dev API/UI/worker stubs and non-canonical ports (`:3100`, `:9101`,
+  `:9102`) may be present inside the Pro-owned project.
+- Explicit `non-production` / fail-closed entitlement stubs if useful for demos.
+- Digested private images and a class `pro-dev.lock.yaml`.
 
-Every stub must be labeled `non-production`, return its current mode, and have a
-test proving that the default configuration fails closed. The two required class
-acknowledgements are `SIRIUS_PRO_DEV_ALLOW_ALL=true` and
-`SIRIUS_PRO_DEV_ACKNOWLEDGE_NON_PRODUCTION=true`; the overlay validator must reject
-missing or false values.
+These do **not** replace the must-ship private build-root and canonical-port
+criteria.
 
 ### C. Deferred to the full program
 
@@ -85,78 +106,63 @@ missing or false values.
 
 ## Evidence and blockers at cut selection
 
-- `sirius-pro` is a skeleton at commit `16d483e`: no Compose file, Dockerfile, Go
-  module, UI package, or worker exists yet.
-- `sirius-entitlements` is a skeleton at commit `ff1e4e2`.
-- `sirius-release` has the private supply-chain bootstrap at commit `c7bbdc6`, but no
-  product image pipeline has been instantiated.
+- `sirius-pro` previously started as a skeleton; local private work may already
+  include companion stubs (for example services on `:9101`/`:3100`/`:9102`). Those
+  stubs are **not** cutoff completion.
 - `sirius-pro/core.lock.yaml` already pins Community `v1.1.0` source commit
   `b61b47b468cfc5c837a5bde50eeafe52df4fe10d` and all six release digests.
-- Community main is `a279198a3`; its API Module/OpenAPI contracts are green, but it is
-  not the immutable six-image class input. Use the `v1.1.0` lock for this cut.
+- Community main advances separately; it is not the immutable six-image class input.
+  Use the `v1.1.0` lock for this cut.
 - The last independent range receipt (2026-07-31) says VMID 220 was started and
   Community UI/API returned 200. The installed checkout was previously recorded as
   `/home/agi/Sirius` using mutable `latest`; live state must be re-read before change.
-- This agent sandbox rejects all network sockets with `Operation not permitted`, so
-  it cannot re-verify the range or use the jump host. That is an execution-environment
-  restriction, not evidence that VMID 220 is down.
-- The private repositories are outside this run's writable workspace. Private source
-  must not be staged in the public Sirius checkout as a workaround.
-- This managed workspace also exposes the public repository's `.git` directory as
-  read-only. The scoped documentation changes are present in the working tree, but
-  `git add` fails while creating `.git/index.lock`; a later writable run must commit
-  them before private implementation starts.
-- Private Pro-dev image digests and a least-privilege GHCR pull credential for the
-  range do not yet exist.
+- Companion sidecars published privately while `/home/agi/Sirius` still owns
+  `:3000`/`:9001` do **not** meet success.
+- Private repositories are outside the public Sirius checkout; private source must
+  not be staged in Community as a workaround.
+- Private Pro images, GHCR pull credentials, and a network-capable operator session
+  remain execution blockers for the deployment gate—not for documenting this cutoff.
 
-No additional public contract is a blocker for the companion cut. The real blockers
-are private implementation, private image publication, GHCR read access on the guest,
-and a network-capable operator session for the approved deployment gate.
+No additional public product contract is a blocker for the private build-root cut.
+The real blockers are private Compose/build-root implementation that owns the
+canonical ports, private image publication as needed, GHCR read access on the guest,
+backup/approval gates, and a network-capable operator session for the approved
+deployment gate.
 
 ## Ordered execution checklist
 
-### 1. Implement and validate the private cut — agent
+### 1. Implement and validate the private build root — agent
 
 Run the next agent cycle with
 `/Users/oz/Projects/Sirius-Project/private/sirius-pro` as a writable workspace. Own
-only that repository. Add the three services and deployment files described above.
+only that repository. Establish a Pro-owned Compose project that:
 
-Required validation after the files exist:
+1. Consumes Community solely via `core.lock.yaml` digests (`v1.1.0`).
+2. Owns `:3000` and `:9001` in the rendered Compose project.
+3. Treats companion sidecars as optional overlays, not as success.
+4. Rejects mutable Community/private image references in validation.
+
+Required validation after the files exist (adjust paths to the private layout):
 
 ```bash
 cd /Users/oz/Projects/Sirius-Project/private/sirius-pro
-make test
-(cd apps/api && go test ./...)
-(cd apps/worker && go test ./...)
-npm --prefix apps/ui ci
-npm --prefix apps/ui run lint
-npm --prefix apps/ui run build
+# Native tests for any private packages that exist
+# Compose/config validation that lists rendered images and requires @sha256:
 bash scripts/validate-pro-dev-compose.sh
 git diff --check
 ```
 
-The validation script must render the Community base + production override + both
-private overlays with fixture-only values, list all ten rendered image references,
-and reject any reference that lacks `@sha256:`. Commit locally; do not push.
+Commit locally in private; do not push without a human gate.
 
 ### 2. Review, publish, and record private images — human gates
 
 1. Human reviews the local private diff and explicitly approves push/PR/merge.
-2. Human separately approves the private image workflow dispatch.
-3. The workflow builds each image once from the accepted full source SHA, tests it,
-   pushes a source-SHA tag, resolves the three digests, and writes the values used for
-   `pro-dev.lock.yaml`. This class cut does not claim the deferred Phase 6 promotion
-   guarantees.
-4. Human provisions a least-privilege `read:packages` credential to the range guest.
-   Do not commit it or copy it into Compose/YAML.
-
-Planned dispatch shape after the private workflow exists:
-
-```bash
-gh workflow run pro-dev-images.yml \
-  --repo "$SIRIUS_PRO_REPOSITORY" \
-  -f source_sha=<accepted-full-40-character-sha>
-```
+2. Human separately approves any private image workflow dispatch required for the
+   Pro-owned project.
+3. Digests used on the range are recorded; this class cut does not claim deferred
+   Phase 6 promotion guarantees.
+4. Human provisions a least-privilege `read:packages` credential to the range guest
+   when private images are required. Do not commit it or copy it into Compose/YAML.
 
 ### 3. Re-enter the range read-only — human/operator
 
@@ -171,6 +177,7 @@ ssh -i ~/.ssh/dev01_agi -o BatchMode=yes \
 Before approval to change anything, collect:
 
 ```bash
+# Current Community path (legacy; must not remain the active Pro-dev root)
 cd /home/agi/Sirius
 git status --short --branch
 git rev-parse HEAD
@@ -178,6 +185,9 @@ docker compose ps
 docker ps --format '{{.Names}} {{.Image}} {{.Status}}'
 curl -fsS http://127.0.0.1:9001/health
 curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/
+
+# Target private root (may be absent before cutover)
+ls -la /home/agi/sirius-pro 2>/dev/null || true
 ```
 
 If this path fails, stop and report whether the failure is jump-host SSH, guest SSH,
@@ -200,12 +210,13 @@ docker exec sirius-postgres sh -lc \
 test -s /home/agi/backups/sirius-pre-pro-dev.dump
 ```
 
-The operator copies the reviewed private `deployments/` artifacts to
-`/home/agi/sirius-pro/deployments/`, confirms `/home/agi/Sirius` has no tracked local
-changes, fetches the public `v1.1.0` tag, and moves the public checkout to that exact
-tag. Existing ignored `.env` and secret files remain Vault-derived runtime mirrors.
+Stage the reviewed private tree at `/home/agi/sirius-pro`. Retire `/home/agi/Sirius`
+from the development path: either leave it unused or move it to a detached
+read-only pin of public `v1.1.0` (same commit as `core.lock.yaml`). Do not develop
+against `/home/agi/Sirius` after cutover.
 
 ```bash
+# Optional read-only Community pin (not the active Compose root)
 cd /home/agi/Sirius
 test -z "$(git status --porcelain --untracked-files=no)"
 git fetch --tags origin v1.1.0
@@ -213,10 +224,12 @@ git checkout --detach v1.1.0
 test "$(git rev-parse HEAD)" = b61b47b468cfc5c837a5bde50eeafe52df4fe10d
 ```
 
-The `v1.1.0` Community core migrator may apply core migrations on first start. The
-class cut adds no Pro migration; the backup remains mandatory for the core change.
+Existing ignored `.env` and secret files remain Vault-derived runtime mirrors;
+copy or re-point them into the Pro-owned project as the operator runbook requires,
+without committing secrets.
 
-Log in to GHCR only via standard input from the human-provided ephemeral environment:
+Log in to GHCR only via standard input from the human-provided ephemeral environment
+when private images are required:
 
 ```bash
 printf '%s' "$SIRIUS_PRO_GHCR_PULL_TOKEN" | \
@@ -226,75 +239,59 @@ unset SIRIUS_PRO_GHCR_PULL_TOKEN
 
 ### 5. Render, deploy, and verify — agent observes; human executes
 
-Use the existing Compose project name so named Community volumes are reused:
+Deploy from `/home/agi/sirius-pro` as the Compose project directory (exact compose
+file names follow the private repository layout). The project must own `:3000` and
+`:9001` and pull Community only by locked digests.
+
+Illustrative shape (adjust `-f` paths to the private tree):
 
 ```bash
-cd /home/agi/Sirius
-docker compose --env-file /home/agi/Sirius/.env \
-  --project-directory /home/agi/Sirius -p sirius \
-  -f /home/agi/Sirius/docker-compose.yaml \
-  -f /home/agi/Sirius/docker-compose.prod.yaml \
-  -f /home/agi/sirius-pro/deployments/docker-compose.community-lock.yaml \
-  -f /home/agi/sirius-pro/deployments/docker-compose.pro-dev.yaml \
+cd /home/agi/sirius-pro
+docker compose --env-file .env \
+  --project-directory /home/agi/sirius-pro -p sirius \
+  -f <pro-owned-compose-files> \
   config --images
 
-docker compose --env-file /home/agi/Sirius/.env \
-  --project-directory /home/agi/Sirius -p sirius \
-  -f /home/agi/Sirius/docker-compose.yaml \
-  -f /home/agi/Sirius/docker-compose.prod.yaml \
-  -f /home/agi/sirius-pro/deployments/docker-compose.community-lock.yaml \
-  -f /home/agi/sirius-pro/deployments/docker-compose.pro-dev.yaml \
+docker compose --env-file .env \
+  --project-directory /home/agi/sirius-pro -p sirius \
+  -f <pro-owned-compose-files> \
   pull
 
-docker compose --env-file /home/agi/Sirius/.env \
-  --project-directory /home/agi/Sirius -p sirius \
-  -f /home/agi/Sirius/docker-compose.yaml \
-  -f /home/agi/Sirius/docker-compose.prod.yaml \
-  -f /home/agi/sirius-pro/deployments/docker-compose.community-lock.yaml \
-  -f /home/agi/sirius-pro/deployments/docker-compose.pro-dev.yaml \
+docker compose --env-file .env \
+  --project-directory /home/agi/sirius-pro -p sirius \
+  -f <pro-owned-compose-files> \
   up -d
 ```
 
-Acceptance probes:
+Acceptance probes (canonical ports are required):
 
 ```bash
 curl -fsS http://127.0.0.1:9001/health
 curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/
-curl -fsS http://127.0.0.1:9101/health
-curl -fsS http://127.0.0.1:9101/api/pro/v1/status
-curl -fsS http://127.0.0.1:9101/api/pro/v1/reports
-curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3100/
-curl -fsS http://127.0.0.1:9102/health
+# Confirm active Compose project directory is /home/agi/sirius-pro
+# Confirm rendered Community images match core.lock.yaml digests
+# Confirm /home/agi/Sirius is not the active project directory
 ```
 
-The status/report responses must explicitly identify `pro-dev`,
-`entitlement_mode=dev_allow_all`, and stub limitations. The instructor then verifies
-the Community scan path and the Pro-dev page from the approved client path.
+Optional sidecar probes (`:9101`, `:3100`, `:9102`) may be recorded if those
+services exist; they are **not** sufficient for acceptance.
 
-### 6. Prove Community-only rollback — human deployment gate
+The instructor then verifies the scan/UI path on the canonical ports from the
+approved client path.
 
-Do not use `down --volumes` or delete any volume. Reconcile the project without the
-Pro-dev overlay:
+### 6. Prove Community-data rollback / restore — human deployment gate
 
-```bash
-cd /home/agi/Sirius
-docker compose --env-file /home/agi/Sirius/.env \
-  --project-directory /home/agi/Sirius -p sirius \
-  -f /home/agi/Sirius/docker-compose.yaml \
-  -f /home/agi/Sirius/docker-compose.prod.yaml \
-  -f /home/agi/sirius-pro/deployments/docker-compose.community-lock.yaml \
-  up -d --remove-orphans
-curl -fsS http://127.0.0.1:9001/health
-curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/
-```
+Do not use `down --volumes` or delete any volume without a separate destructive
+approval. Prove that core data remains readable after cutover operations, and that
+the Pro-owned project can be reconciled without destroying Community volumes.
 
-Verify an existing scan remains readable. Restore the accepted Pro-dev overlay only
-after that evidence is captured and the human approves it.
+Verify an existing scan remains readable. Capture evidence before any further
+overlay changes. Human approval is required before restoring or advancing state.
 
 ## Immediate human gate
 
-Start the next bounded agent run with this Sirius repository's `.git` metadata and
-the private `sirius-pro` repository writable. Approve local commits of this handoff
-and implementation of the three stub images plus the two deployment overlays. Do not
-approve push, publication, range mutation, or deployment yet; each remains a separate
-gate above.
+Approve documentation of this private build-root cutoff on the Community feature
+branch, then continue private `sirius-pro` implementation so the range Compose root
+moves to `/home/agi/sirius-pro` with locked Community digests on `:3000`/`:9001`.
+Do not treat companion sidecars alone as done. Do not approve range mutation,
+publication, or deployment without the separate gates above.

--- a/programs/complete-split-deploy-to-range/PROGRAM.md
+++ b/programs/complete-split-deploy-to-range/PROGRAM.md
@@ -9,7 +9,7 @@ acceptance_criteria:
   - "The Pro Compose overlay deploys to the approved SIRIUS range host (VMID 220 / 10.0.10.20), passes health and instructor-path E2E checks, and can be removed while Community and core data remain healthy."
   - "License valid, expired, grace, renewed, Community-to-Pro, Pro upgrade, and Pro-to-Community-only lifecycle tests pass with existing scan data retained and readable."
   - "The public repository and artifacts contain no private source, module paths, registry references, credentials, or Pro runtime code after final release and deployment."
-  - "A parallel class-ready Pro-dev cut may be demonstrated before full closeout only when it consumes immutable Community images, clearly labels every stub/dev behavior, and proves removal leaves Community and core data healthy; this does not satisfy or delete the full Pro release criteria above."
+  - "A parallel class-ready Pro-dev cut may be demonstrated before full closeout only when private OpenSecurity-Infosec/sirius-pro is the sole mutable Compose/build root on the range (/home/agi/sirius-pro), Community is consumed only via core.lock.yaml immutable digests (v1.1.0), and canonical ports :3000/:9001 are owned by that Pro project with /home/agi/Sirius retired from the development path; companion sidecars on :3100/:9101/:9102 alone do not satisfy the cut; this does not satisfy or delete the full Pro release criteria above."
 human_gates:
   - "Human approval before every push, pull request, merge, public or private tag/release, package publication, or promotion."
   - "Human approval before creating or rotating signing identities, KMS keys, license keys, credentials, secrets, package namespaces, or external infrastructure."
@@ -64,11 +64,14 @@ Dependencies and order:
 
 Accelerated parallel track:
 
-- After the completed API Module and OpenAPI contracts, the class-ready cut may build
-  a private companion API/UI/worker composition without waiting for Phase 3.3-6.
-- It must use the existing Community `v1.1.0` digests, remain visibly Pro-dev,
-  default to fail-closed capability checks, avoid Pro migrations, and prove
-  Community-only rollback.
+- After the completed API Module and OpenAPI contracts, the class-ready cut may
+  establish a private Pro working-tree / Compose build root on the range without
+  waiting for Phase 3.3-6 or shipping product features.
+- Success is private `sirius-pro` at `/home/agi/sirius-pro` as the sole mutable
+  Compose/build root, Community only via `core.lock.yaml` digests (`v1.1.0`),
+  canonical ports `:3000`/`:9001` owned by that project, and `/home/agi/Sirius`
+  retired from the development path. Companion sidecars alone do not complete the
+  cut. No private Community fork; shared fixes remain public-first (ADR-001/002).
 - The full ordered dependency chain and every original acceptance criterion remain
   required for an actual Pro release. See
   `programs/complete-split-deploy-to-range/CLASS_READY_CUT.md`.
@@ -148,15 +151,19 @@ Tasks:
 - [x] Inspect private scaffold, immutable lock, Community Compose state, and prior
   range evidence
 - [x] Define the class-ready must/stub/deferred boundary and exact execution checklist
-- [ ] Implement and locally validate private companion API/UI/worker images plus
-  Community-lock and Pro-dev Compose overlays
-- [ ] Cross separate human gates for private push/review, image publication, GHCR pull
-  access, range backup, and deployment
-- [ ] Deploy, run class/instructor probes, prove Community-only rollback/data health,
-  and optionally restore the accepted Pro-dev state
+- [x] Reframe class success as private working-tree/build-root cutoff (not companion
+  sidecars alone); document in `CLASS_READY_CUT.md`
+- [ ] Implement and locally validate private `sirius-pro` as the Pro-owned Compose
+  build root that consumes `core.lock.yaml` digests and owns `:3000`/`:9001`
+- [ ] Cross separate human gates for private push/review, image publication (if any),
+  GHCR pull access, range backup, and deployment
+- [ ] Deploy so `/home/agi/sirius-pro` is the active root, retire `/home/agi/Sirius`
+  from the development path, verify canonical ports and locked digests, prove data
+  health
 
 Class-ready is an accelerated demonstration milestone only. It does not mark Stages
-2-5 or the program acceptance criteria complete.
+2-5 or the program acceptance criteria complete. Optional Pro-dev sidecars on
+`:3100`/`:9101`/`:9102` are not the acceptance signal.
 
 ## Stage 3: Entitlements and Enterprise Reporting
 
@@ -284,7 +291,7 @@ Local task evidence (cycle 1):
 - `next_action`: Inventory existing queue payloads and implement bifurcation task 3.3.
 
 This task is retained unchanged and resumes after the class-ready cut, or earlier only
-if the companion design reveals a concrete event-contract blocker.
+if the private build-root cutoff reveals a concrete event-contract blocker.
 
 Local task evidence:
 
@@ -331,9 +338,9 @@ Completion evidence:
   - `programs/bifurcation/PROGRAM.md`
 - `criteria`:
   - Establish the actual private scaffold and immutable Community input state.
-  - Define a runnable Pro-dev composition that does not require unfinished public
-    contracts or weaken Community independence.
-  - Record must-ship, stubbed, and deferred scope with commands and human gates.
+  - Define class-ready success as a private Pro working-tree/build-root cutoff that
+    does not require unfinished public contracts or weaken Community independence.
+  - Record must-ship, optional stub, and deferred scope with commands and human gates.
   - Discover and attempt the previously proven range access path without changing
     routes, VM state, services, or credentials.
 - `validation`:
@@ -343,11 +350,11 @@ Completion evidence:
   - Exact direct and ProxyJump reachability probes
   - Program evaluation validation and `git diff --check`
 - `next_task_id`: `complete-split-deploy-to-range.scr.t002`
-- `next_action`: Run the next bounded cycle from a workspace that can write this
-  repository's Git metadata and
-  `/Users/oz/Projects/Sirius-Project/private/sirius-pro`; first commit this handoff,
-  then implement and locally validate the private cut, but stop before
-  push/publication or range mutation.
+- `next_action`: Implement and locally validate private `sirius-pro` so the range
+  Compose/build root becomes `/home/agi/sirius-pro` with Community only via
+  `core.lock.yaml` digests and Pro ownership of `:3000`/`:9001`; companion sidecars
+  alone are not acceptance. Stop before push/publication or range mutation without
+  human gates.
 
 Cycle 3 evidence:
 
@@ -363,12 +370,11 @@ Cycle 3 evidence:
 - This sandbox blocked direct TCP, route inspection, HTTP, and the exact ProxyCommand
   with `Operation not permitted`; no network, route, VM, container, or secret change
   was attempted.
-- The managed sandbox also rejected `git add` because `.git/index.lock` cannot be
-  created. The scoped working-tree changes are validated but require a writable Git
-  metadata root before they can satisfy the always-commit gate.
 - Decision and execution handoff:
   `programs/complete-split-deploy-to-range/CLASS_READY_CUT.md`.
 - Evaluation:
   `programs/complete-split-deploy-to-range/evaluations/complete-split-deploy-to-range.scr.t001.md`.
-- Decision: the planning/discovery cut is accepted. Stop at the writable Git/private
-  repository and network-capable human gate before implementation or range work.
+- Decision: planning/discovery accepted. A later docs correction reframes class
+  success as the private working-tree/build-root cutoff; companion sidecars alone
+  do not complete it. Continue private implementation toward `/home/agi/sirius-pro`
+  owning `:3000`/`:9001` with locked Community digests.

--- a/programs/complete-split-deploy-to-range/PROGRAM.md
+++ b/programs/complete-split-deploy-to-range/PROGRAM.md
@@ -1,6 +1,6 @@
 ---
 goal: "Complete the Sirius Community/Pro product split, publish a runnable Pro distribution that consumes immutable Community releases, and deploy and verify that Pro distribution in the approved range environment."
-status: "active"
+status: "waiting"
 acceptance_criteria:
   - "The existing bifurcation program completes its public contracts, entitlement platform, first Pro vertical, compatibility automation, and release closeout without weakening the completed Community release or private-foundation controls."
   - "A tagged Community core release remains independently runnable without private credentials, packages, repositories, licenses, or Pro artifacts and passes leakage, upgrade, and regression checks."
@@ -9,6 +9,7 @@ acceptance_criteria:
   - "The Pro Compose overlay deploys to the approved SIRIUS range host (VMID 220 / 10.0.10.20), passes health and instructor-path E2E checks, and can be removed while Community and core data remain healthy."
   - "License valid, expired, grace, renewed, Community-to-Pro, Pro upgrade, and Pro-to-Community-only lifecycle tests pass with existing scan data retained and readable."
   - "The public repository and artifacts contain no private source, module paths, registry references, credentials, or Pro runtime code after final release and deployment."
+  - "A parallel class-ready Pro-dev cut may be demonstrated before full closeout only when it consumes immutable Community images, clearly labels every stub/dev behavior, and proves removal leaves Community and core data healthy; this does not satisfy or delete the full Pro release criteria above."
 human_gates:
   - "Human approval before every push, pull request, merge, public or private tag/release, package publication, or promotion."
   - "Human approval before creating or rotating signing identities, KMS keys, license keys, credentials, secrets, package namespaces, or external infrastructure."
@@ -60,6 +61,17 @@ Dependencies and order:
 5. Publish approved Community and Pro release candidates.
 6. Back up the range data, deploy the digest-pinned Pro overlay, execute E2E/lifecycle
    tests, prove overlay removal/data integrity, then restore the accepted Pro state.
+
+Accelerated parallel track:
+
+- After the completed API Module and OpenAPI contracts, the class-ready cut may build
+  a private companion API/UI/worker composition without waiting for Phase 3.3-6.
+- It must use the existing Community `v1.1.0` digests, remain visibly Pro-dev,
+  default to fail-closed capability checks, avoid Pro migrations, and prove
+  Community-only rollback.
+- The full ordered dependency chain and every original acceptance criterion remain
+  required for an actual Pro release. See
+  `programs/complete-split-deploy-to-range/CLASS_READY_CUT.md`.
 
 Repository-native validation:
 
@@ -117,6 +129,34 @@ Tasks:
 - [x] Finish API Module contract task 3.1 and publish an immutable go-api pin
 - [ ] Complete API inventory/OpenAPI, event, UI, and engine extension contracts
 - [ ] Publish and verify the tagged compatible Community contract release
+
+## Parallel Stage CR: Class-ready Pro-dev Cut
+
+Owned paths for the planning/discovery task:
+
+- `programs/complete-split-deploy-to-range/PROGRAM.md`
+- `programs/complete-split-deploy-to-range/CLASS_READY_CUT.md`
+- `programs/complete-split-deploy-to-range/evaluations/`
+- `programs/bifurcation/PROGRAM.md`
+
+Owned path for the next implementation task (requires a new writable workspace):
+
+- `/Users/oz/Projects/Sirius-Project/private/sirius-pro`
+
+Tasks:
+
+- [x] Inspect private scaffold, immutable lock, Community Compose state, and prior
+  range evidence
+- [x] Define the class-ready must/stub/deferred boundary and exact execution checklist
+- [ ] Implement and locally validate private companion API/UI/worker images plus
+  Community-lock and Pro-dev Compose overlays
+- [ ] Cross separate human gates for private push/review, image publication, GHCR pull
+  access, range backup, and deployment
+- [ ] Deploy, run class/instructor probes, prove Community-only rollback/data health,
+  and optionally restore the accepted Pro-dev state
+
+Class-ready is an accelerated demonstration milestone only. It does not mark Stages
+2-5 or the program acceptance criteria complete.
 
 ## Stage 3: Entitlements and Enterprise Reporting
 
@@ -216,14 +256,14 @@ Local task evidence (cycle 1):
 - Decision: API inventory/OpenAPI accepted; continue with the event contract as
   `complete-split-deploy-to-range.s2.t003`.
 
-## Current task
+## Paused full-track task
 
 - `task_id`: `complete-split-deploy-to-range.s2.t003`
 - `stage`: `2 Complete Public Contracts`
 - `cycle`: `2`
 - `attempt`: `1`
 - `assigned_role`: `grok`
-- `status`: `active`
+- `status`: `deferred`
 - `verdict`: `pending`
 - `artifact_verdict`: `pending`
 - `loop_decision`: `continue`
@@ -242,6 +282,9 @@ Local task evidence (cycle 1):
   - JSON schema validation and negative fixtures
   - Existing Community queue regression tests
 - `next_action`: Inventory existing queue payloads and implement bifurcation task 3.3.
+
+This task is retained unchanged and resumes after the class-ready cut, or earlier only
+if the companion design reveals a concrete event-contract blocker.
 
 Local task evidence:
 
@@ -269,3 +312,63 @@ Completion evidence:
   `programs/complete-split-deploy-to-range/evaluations/complete-split-deploy-to-range.s2.t001.md`.
 - Decision: task `complete-split-deploy-to-range.s2.t001` accepted; continue with API
   inventory and OpenAPI as `complete-split-deploy-to-range.s2.t002`.
+
+## Current class-ready task
+
+- `task_id`: `complete-split-deploy-to-range.scr.t001`
+- `stage`: `Parallel Class-Ready Cut`
+- `cycle`: `3`
+- `attempt`: `1`
+- `assigned_role`: `sol`
+- `status`: `done`
+- `verdict`: `accepted`
+- `artifact_verdict`: `null`
+- `loop_decision`: `human_gate`
+- `owned_paths`:
+  - `programs/complete-split-deploy-to-range/PROGRAM.md`
+  - `programs/complete-split-deploy-to-range/CLASS_READY_CUT.md`
+  - `programs/complete-split-deploy-to-range/evaluations/complete-split-deploy-to-range.scr.t001.md`
+  - `programs/bifurcation/PROGRAM.md`
+- `criteria`:
+  - Establish the actual private scaffold and immutable Community input state.
+  - Define a runnable Pro-dev composition that does not require unfinished public
+    contracts or weaken Community independence.
+  - Record must-ship, stubbed, and deferred scope with commands and human gates.
+  - Discover and attempt the previously proven range access path without changing
+    routes, VM state, services, or credentials.
+- `validation`:
+  - Private repository tree and Dockerfile/Compose inventory
+  - Community production Compose render for `v1.1.0`
+  - Existing core-manifest contract tests
+  - Exact direct and ProxyJump reachability probes
+  - Program evaluation validation and `git diff --check`
+- `next_task_id`: `complete-split-deploy-to-range.scr.t002`
+- `next_action`: Run the next bounded cycle from a workspace that can write this
+  repository's Git metadata and
+  `/Users/oz/Projects/Sirius-Project/private/sirius-pro`; first commit this handoff,
+  then implement and locally validate the private cut, but stop before
+  push/publication or range mutation.
+
+Cycle 3 evidence:
+
+- Private repositories are clean skeletons at `sirius-pro@16d483e`,
+  `sirius-entitlements@ff1e4e2`, and `sirius-release@c7bbdc6`; only the release repo
+  has a bootstrap Dockerfile and no private product Compose file exists.
+- `sirius-pro/core.lock.yaml` has exact, digest-addressed Community `v1.1.0` inputs.
+- The current Community Compose renders all seven service image uses (six distinct
+  images; API is also the one-shot migrator) for `IMAGE_TAG=v1.1.0`.
+- Prior range evidence records `/home/agi/Sirius`, VMID 220, and the exact
+  `agi@192.168.123.200` ProxyJump/ProxyCommand path. A 2026-07-31 receipt reports UI
+  and API 200 after the VM was started.
+- This sandbox blocked direct TCP, route inspection, HTTP, and the exact ProxyCommand
+  with `Operation not permitted`; no network, route, VM, container, or secret change
+  was attempted.
+- The managed sandbox also rejected `git add` because `.git/index.lock` cannot be
+  created. The scoped working-tree changes are validated but require a writable Git
+  metadata root before they can satisfy the always-commit gate.
+- Decision and execution handoff:
+  `programs/complete-split-deploy-to-range/CLASS_READY_CUT.md`.
+- Evaluation:
+  `programs/complete-split-deploy-to-range/evaluations/complete-split-deploy-to-range.scr.t001.md`.
+- Decision: the planning/discovery cut is accepted. Stop at the writable Git/private
+  repository and network-capable human gate before implementation or range work.

--- a/programs/complete-split-deploy-to-range/evaluations/complete-split-deploy-to-range.scr.t001.md
+++ b/programs/complete-split-deploy-to-range/evaluations/complete-split-deploy-to-range.scr.t001.md
@@ -1,0 +1,50 @@
+---
+goal_id: complete-split-deploy-to-range
+task_id: complete-split-deploy-to-range.scr.t001
+run_id: parent-complete-split-deploy-to-range-scr-t001-cycle3-20260731
+execution_kind: parent
+cycle: 3
+attempt: 1
+evaluator_role: sol
+evaluated_at: "2026-07-31T21:18:04Z"
+evidence_paths: "CLASS_READY_CUT.md; private repo commits 16d483e/ff1e4e2/c7bbdc6; ellingson-range receipts dated 2026-07-29 and 2026-07-31; Community Compose render; direct TCP/HTTP and exact ProxyCommand probes"
+criteria:
+  - id: grounded-current-state
+    status: pass
+    evidence:
+      - "All three private repository trees, commits, locks, Compose/Dockerfile presence, Community Compose files, and Phase 5 overlay requirements were inspected."
+  - id: minimal-class-ready-cut
+    status: pass
+    evidence:
+      - "The cut uses six immutable Community v1.1.0 digests and adds private companion API/UI/worker images without waiting for event/UI/engine contracts."
+  - id: scope-and-gates
+    status: pass
+    evidence:
+      - "Must-ship, stubbed/dev, and deferred work are explicit, with ordered agent/human commands and separate publication/deployment gates."
+  - id: range-access-discovery
+    status: pass
+    evidence:
+      - "Prior receipts identify ProxyCommand agi@192.168.123.200 to agi@10.0.10.20 with ~/.ssh/dev01_agi and /home/agi/Sirius; this sandbox rejected the exact read-only probe with Operation not permitted."
+  - id: community-independence
+    status: pass
+    evidence:
+      - "No private implementation was written to Community; the cut retains a Community-only locked overlay and a no-volume-deletion rollback path."
+verdict: accepted
+artifact_verdict: null
+loop_decision: human_gate
+residual_risk:
+  - "The private Pro-dev images and Compose overlays do not exist yet."
+  - "The range guest's live state cannot be re-read from this network-restricted sandbox."
+  - "A least-privilege private GHCR pull credential for VMID 220 is not evidenced."
+  - "The last range receipt shows Community was healthy, but the earlier install used mutable latest and an older checkout."
+  - "The managed sandbox exposes .git as read-only, so the validated working-tree changes cannot be committed in this run."
+---
+
+# Evaluation
+
+The accelerated class-ready design and execution handoff are accepted. No unfinished
+public contract blocks the companion composition. Stop at a human gate because the
+next task requires writes to the private `sirius-pro` repository and later range
+access, private image publication, credentials, backup, and deployment approvals.
+The immediate continuation also needs writable Git metadata to commit this cycle's
+scoped public program artifacts.

--- a/programs/complete-split-deploy-to-range/evaluations/complete-split-deploy-to-range.scr.t001.md
+++ b/programs/complete-split-deploy-to-range/evaluations/complete-split-deploy-to-range.scr.t001.md
@@ -16,11 +16,12 @@ criteria:
   - id: minimal-class-ready-cut
     status: pass
     evidence:
-      - "The cut uses six immutable Community v1.1.0 digests and adds private companion API/UI/worker images without waiting for event/UI/engine contracts."
+      - "Planning accepted a runnable private cut using Community v1.1.0 digests without waiting for event/UI/engine contracts."
+      - "Superseding docs correction (same program paths): success is private sirius-pro as sole mutable Compose/build root on the range (/home/agi/sirius-pro) owning :3000/:9001; companion sidecars on :3100/:9101/:9102 alone do not complete the cutoff."
   - id: scope-and-gates
     status: pass
     evidence:
-      - "Must-ship, stubbed/dev, and deferred work are explicit, with ordered agent/human commands and separate publication/deployment gates."
+      - "Must-ship, optional stub/dev, and deferred work are explicit, with ordered agent/human commands and separate publication/deployment gates."
   - id: range-access-discovery
     status: pass
     evidence:
@@ -28,23 +29,26 @@ criteria:
   - id: community-independence
     status: pass
     evidence:
-      - "No private implementation was written to Community; the cut retains a Community-only locked overlay and a no-volume-deletion rollback path."
+      - "No private implementation was written to Community; Community remains immutable digests via core.lock.yaml; no private Community fork; shared fixes stay public-first per ADR-001/002."
 verdict: accepted
 artifact_verdict: null
 loop_decision: human_gate
 residual_risk:
-  - "The private Pro-dev images and Compose overlays do not exist yet."
+  - "Private Pro Compose/build-root ownership of canonical ports on the range is not yet deployed."
+  - "Companion sidecar stubs (if present) must not be mistaken for cutoff completion."
   - "The range guest's live state cannot be re-read from this network-restricted sandbox."
   - "A least-privilege private GHCR pull credential for VMID 220 is not evidenced."
-  - "The last range receipt shows Community was healthy, but the earlier install used mutable latest and an older checkout."
-  - "The managed sandbox exposes .git as read-only, so the validated working-tree changes cannot be committed in this run."
+  - "The last range receipt shows Community was healthy, but the earlier install used mutable latest and an older checkout under /home/agi/Sirius."
 ---
 
 # Evaluation
 
-The accelerated class-ready design and execution handoff are accepted. No unfinished
-public contract blocks the companion composition. Stop at a human gate because the
-next task requires writes to the private `sirius-pro` repository and later range
-access, private image publication, credentials, backup, and deployment approvals.
-The immediate continuation also needs writable Git metadata to commit this cycle's
-scoped public program artifacts.
+The accelerated class-ready planning/discovery handoff is accepted. A later
+correction on the same program paths reframes class success: private
+`OpenSecurity-Infosec/sirius-pro` must become the sole mutable Compose/build root
+at `/home/agi/sirius-pro`, consuming Community only through `core.lock.yaml`
+immutable digests (`v1.1.0`), with Pro ownership of `:3000`/`:9001` and
+`/home/agi/Sirius` retired from the development path. Companion sidecars on
+`:3100`/`:9101`/`:9102` alone do **not** satisfy the cutoff. No unfinished public
+product contract blocks this cut. Stop at human gates for private implementation
+writes, image publication (if needed), credentials, backup, and range deployment.


### PR DESCRIPTION
## Summary
- Reframe class-ready success as private `sirius-pro` owning `/home/agi/sirius-pro` and canonical `:3000`/`:9001`.
- Community is digest-only via `core.lock.yaml`; companion sidecars alone do not satisfy the cutoff.
- No product features; documents the development cutoff only.

## Test plan
- [x] Docs lint / pre-commit on branch
- [ ] Confirm narrative matches private `feature/pro-dev-cutoff` compose root