### PR TITLE
feat(ui): add build-time extension and neutral capability registry

### DIFF
--- a/documentation/dev/architecture/ADR.004-extension-contracts.md
+++ b/documentation/dev/architecture/ADR.004-extension-contracts.md
@@ -51,6 +51,16 @@ Today the API registers Fiber routes through a `RouteSetter` interface wired in 
 - Existing seam to build on: `sirius-api/routes/routes.go` `RouteSetter`.
 - Do not publish npm packages on day one; pin+overlay mirrors engine component pins.
 - A test extension adding one API route, one UI page, and one event consumer is the Phase 3 exit criterion.
+- The Community UI registry lives under `sirius-ui/src/ui/extensions/`. Community
+  declarations are registered first; a private build overlays
+  `registered.ts` with additional routes, navigation, widgets, and settings
+  panels. Registry construction rejects duplicate contribution IDs and route
+  patterns before the application renders.
+- UI contributions declare opaque `requiredCapabilities` values. The
+  `SiriusCapabilityProvider` exposes a neutral `SiriusPrincipal` and capability
+  checks to shared components; Community uses its static public capability
+  catalog, while a private build may supply an API-backed provider without
+  changing `Sidebar.tsx` or `Layout.tsx`.
 - Community `/api/v1` OpenAPI, route classification, and reserved-namespace policy live in
   [README.api-openapi-contract.md](README.api-openapi-contract.md) and
   `sirius-api/contracts/`.

--- a/sirius-ui/package.json
+++ b/sirius-ui/package.json
@@ -7,6 +7,7 @@
     "dev": "npx next dev",
     "postinstall": "npx prisma generate",
     "lint": "npx lint",
+    "test:ui-extensions": "tsx src/ui/extensions/registry.test.ts",
     "start": "npx next start"
   },
   "dependencies": {

--- a/sirius-ui/src/components/Layout.tsx
+++ b/sirius-ui/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import Sidebar from "./Sidebar";
 import { Toaster } from "~/components/lib/ui/sonner";
 import { debugLog, debugRouting } from "~/utils/debug";
 import { ActiveConstellationV2Loader } from "~/components/loaders";
+import { uiExtensionRegistry, useCapabilities } from "~/ui/extensions";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -18,6 +19,10 @@ interface LayoutProps {
 const Layout = ({ children, title = "Sirius Scan" }: LayoutProps) => {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const { loading: capabilitiesLoading, hasAll } = useCapabilities();
+  const requiredCapabilities =
+    uiExtensionRegistry.getRequiredCapabilitiesForPath(router.pathname);
+  const hasRouteAccess = hasAll(requiredCapabilities);
 
   // Use useEffect to handle redirects to avoid render loops
   useEffect(() => {
@@ -33,12 +38,32 @@ const Layout = ({ children, title = "Sirius Scan" }: LayoutProps) => {
     }
   }, [session, status, router]);
 
-  // Show loading state while session is loading or while redirecting
-  if (status === "loading") {
+  // Show loading state while session or capability state is loading.
+  if (status === "loading" || capabilitiesLoading) {
     debugLog("Layout", "Rendering loading state - session loading");
     return (
       <div className="flex min-h-screen items-center justify-center">
         <ActiveConstellationV2Loader size="full" label="Loading..." />
+      </div>
+    );
+  }
+
+  // Route declarations are the server-independent authorization seam for
+  // build-time UI extensions. A private route can declare capabilities without
+  // adding Pro-specific branches to this shared layout.
+  if (session?.user && !hasRouteAccess) {
+    debugLog("Layout", "Rendering capability-denied state", {
+      pathname: router.pathname,
+      requiredCapabilities,
+    });
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-900 px-6 text-center text-white">
+        <div>
+          <h1 className="text-2xl font-semibold">Access unavailable</h1>
+          <p className="mt-2 text-gray-400">
+            Your account does not have access to this page.
+          </p>
+        </div>
       </div>
     );
   }

--- a/sirius-ui/src/components/Sidebar.tsx
+++ b/sirius-ui/src/components/Sidebar.tsx
@@ -2,42 +2,16 @@ import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import * as Tooltip from "@radix-ui/react-tooltip";
-import VulnerabilityIcon from "./icons/VulnerabilityIcon";
-import EnvironmentIcon from "./icons/EnvironmentIcon";
-import ScanIcon from "./icons/ScanIcon";
-import AgentIcon from "./icons/AgentIcon";
 import SiriusIcon from "./icons/SiriusIcon";
-
-const navigationItems = [
-  {
-    name: "Scanner",
-    href: "/scanner",
-    matchPaths: ["/scanner"],
-    icon: ScanIcon,
-  },
-  {
-    name: "Vulnerabilities",
-    href: "/vulnerabilities",
-    matchPaths: ["/vulnerabilities", "/vulnerability"],
-    icon: VulnerabilityIcon,
-  },
-  {
-    name: "Environment",
-    href: "/environment",
-    matchPaths: ["/environment", "/host"],
-    icon: EnvironmentIcon,
-  },
-  {
-    name: "Terminal",
-    href: "/terminal",
-    matchPaths: ["/terminal"],
-    icon: AgentIcon,
-  },
-];
+import { uiExtensionRegistry, useCapabilities } from "~/ui/extensions";
 
 const Sidebar = () => {
   const router = useRouter();
+  const { hasAll } = useCapabilities();
   const [mounted, setMounted] = useState(false);
+  const navigationItems = uiExtensionRegistry.navigationItems.filter((item) =>
+    hasAll(item.requiredCapabilities ?? []),
+  );
 
   useEffect(() => {
     setMounted(true);
@@ -114,8 +88,9 @@ const Sidebar = () => {
         <div className="ml-1 space-y-2">
           {navigationItems.map((item, index) => {
             const Icon = item.icon;
-            const isActive = item.matchPaths.some((p) =>
-              router.pathname.startsWith(p),
+            const isActive = item.matchPaths.some((path) =>
+              router.pathname === path ||
+              router.pathname.startsWith(`${path}/`),
             );
 
             return (
@@ -192,7 +167,7 @@ const Sidebar = () => {
                     sideOffset={12}
                     className="animate-fade-in-up z-50 rounded-md border border-violet-500/30 bg-violet-950 px-3 py-2 text-sm font-medium text-white shadow-lg"
                   >
-                    {item.name}
+                    {item.label}
                     <Tooltip.Arrow className="fill-violet-950" />
                   </Tooltip.Content>
                 </Tooltip.Portal>

--- a/sirius-ui/src/pages/_app.tsx
+++ b/sirius-ui/src/pages/_app.tsx
@@ -10,6 +10,10 @@ import { ToastProvider } from "~/components/Toast";
 import ErrorBoundary from "~/components/ErrorBoundary";
 import { createRouteMonitor } from "~/utils/debug";
 import { ActiveConstellationV2Loader } from "~/components/loaders";
+import {
+  SiriusCapabilityProvider,
+  uiExtensionRegistry,
+} from "~/ui/extensions";
 
 const MyApp: AppType<{ session: Session | null }> = ({
   Component,
@@ -54,15 +58,19 @@ const MyApp: AppType<{ session: Session | null }> = ({
   return (
     <ErrorBoundary>
       <SessionProvider session={session}>
-        <ToastProvider>
-          {/* Global navigation loading overlay */}
-          {isNavigating && (
-            <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-gray-900">
-              <ActiveConstellationV2Loader size="full" />
-            </div>
-          )}
-          <Component {...pageProps} />
-        </ToastProvider>
+        <SiriusCapabilityProvider
+          definition={uiExtensionRegistry.capabilityProvider}
+        >
+          <ToastProvider>
+            {/* Global navigation loading overlay */}
+            {isNavigating && (
+              <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-gray-900">
+                <ActiveConstellationV2Loader size="full" />
+              </div>
+            )}
+            <Component {...pageProps} />
+          </ToastProvider>
+        </SiriusCapabilityProvider>
       </SessionProvider>
     </ErrorBoundary>
   );

--- a/sirius-ui/src/ui/extensions/capabilities.tsx
+++ b/sirius-ui/src/ui/extensions/capabilities.tsx
@@ -1,0 +1,287 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type {
+  SiriusCapability,
+  SiriusCapabilityProviderDefinition,
+  SiriusCapabilitySnapshot,
+  SiriusPrincipal,
+} from "./types";
+
+/**
+ * Community capabilities are available without a license or entitlement
+ * service. Keep this list aligned with the public edition-boundary catalog.
+ */
+export const COMMUNITY_CAPABILITIES: readonly SiriusCapability[] = [
+  "scanning.core",
+  "inventory.hosts",
+  "findings.vulnerabilities",
+  "api.public_rest",
+  "ui.dashboard_shell",
+  "auth.local_users",
+  "auth.api_keys",
+  "messaging.queues",
+  "storage.postgres_core",
+  "storage.valkey",
+  "migrations.core",
+  "extensions.module_registry",
+  "ui.scanner",
+  "ui.vulnerabilities",
+  "ui.environment",
+  "ui.terminal",
+  "api.hosts",
+  "api.vulnerabilities",
+  "api.templates",
+  "api.agent_templates",
+  "api.events",
+  "api.snapshots",
+  "api.statistics",
+  "api.scan_control",
+  "engine.scanner",
+  "engine.agent_runtime",
+  "agents.remote",
+  "reporting.basic_export",
+];
+
+export const communityPrincipal: SiriusPrincipal = {
+  subjectId: "community",
+  displayName: "Community",
+  capabilities: COMMUNITY_CAPABILITIES,
+};
+
+export const communityCapabilitySnapshot: SiriusCapabilitySnapshot = {
+  principal: communityPrincipal,
+  source: "community",
+};
+
+export const communityCapabilityProvider: SiriusCapabilityProviderDefinition = {
+  id: "community",
+  initialSnapshot: communityCapabilitySnapshot,
+  load: () => Promise.resolve(communityCapabilitySnapshot),
+};
+
+export function hasRequiredCapabilities(
+  availableCapabilities: readonly SiriusCapability[],
+  requiredCapabilities: readonly SiriusCapability[] = [],
+): boolean {
+  if (requiredCapabilities.length === 0) {
+    return true;
+  }
+
+  const available = new Set(availableCapabilities);
+  return requiredCapabilities.every((capability) => available.has(capability));
+}
+
+interface CapabilityContextValue {
+  principal: SiriusPrincipal;
+  source: string;
+  loading: boolean;
+  error: Error | null;
+  has: (capability: SiriusCapability) => boolean;
+  hasAll: (capabilities: readonly SiriusCapability[]) => boolean;
+}
+
+const defaultCapabilityContext: CapabilityContextValue = {
+  principal: communityPrincipal,
+  source: communityCapabilitySnapshot.source,
+  loading: false,
+  error: null,
+  has: (capability) =>
+    hasRequiredCapabilities(communityPrincipal.capabilities, [capability]),
+  hasAll: (capabilities) =>
+    hasRequiredCapabilities(communityPrincipal.capabilities, capabilities),
+};
+
+const CapabilityContext = createContext<CapabilityContextValue>(
+  defaultCapabilityContext,
+);
+
+interface SiriusCapabilityProviderProps {
+  definition: SiriusCapabilityProviderDefinition;
+  children?: React.ReactNode;
+}
+
+/**
+ * Supplies the neutral principal/capability context used by UI extensions.
+ *
+ * Community uses a static provider. A private build can supply a provider
+ * whose `load` function reads its authenticated entitlement endpoint. A
+ * failed load retains the provider's initial snapshot, which lets a Pro
+ * provider fail closed by choosing an empty initial capability set.
+ */
+export const SiriusCapabilityProvider = ({
+  definition,
+  children,
+}: SiriusCapabilityProviderProps) => {
+  const [snapshot, setSnapshot] = useState(definition.initialSnapshot);
+  const [loading, setLoading] = useState(Boolean(definition.load));
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    setSnapshot(definition.initialSnapshot);
+    setError(null);
+    setLoading(Boolean(definition.load));
+
+    if (!definition.load) {
+      return () => {
+        active = false;
+      };
+    }
+
+    void definition
+      .load()
+      .then((nextSnapshot) => {
+        if (!active) {
+          return;
+        }
+
+        setSnapshot(nextSnapshot);
+        setLoading(false);
+      })
+      .catch((cause: unknown) => {
+        if (!active) {
+          return;
+        }
+
+        setError(
+          cause instanceof Error
+            ? cause
+            : new Error("Capability provider failed to load"),
+        );
+        setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [definition]);
+
+  const has = useCallback(
+    (capability: SiriusCapability) =>
+      hasRequiredCapabilities(snapshot.principal.capabilities, [capability]),
+    [snapshot.principal.capabilities],
+  );
+
+  const hasAll = useCallback(
+    (capabilities: readonly SiriusCapability[]) =>
+      hasRequiredCapabilities(snapshot.principal.capabilities, capabilities),
+    [snapshot.principal.capabilities],
+  );
+
+  const value = useMemo<CapabilityContextValue>(
+    () => ({
+      principal: snapshot.principal,
+      source: snapshot.source,
+      loading,
+      error,
+      has,
+      hasAll,
+    }),
+    [error, has, hasAll, loading, snapshot.principal, snapshot.source],
+  );
+
+  return (
+    <CapabilityContext.Provider value={value}>
+      {children}
+    </CapabilityContext.Provider>
+  );
+};
+
+export const useCapabilities = (): CapabilityContextValue =>
+  useContext(CapabilityContext);
+
+interface CapabilityGateProps {
+  requiredCapabilities: readonly SiriusCapability[];
+  children?: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+export const CapabilityGate = ({
+  requiredCapabilities,
+  children,
+  fallback = null,
+}: CapabilityGateProps) => {
+  const { loading, hasAll } = useCapabilities();
+
+  if (loading && requiredCapabilities.length > 0) {
+    return <>{fallback}</>;
+  }
+
+  return hasAll(requiredCapabilities) ? <>{children}</> : <>{fallback}</>;
+};
+
+interface ApiCapabilityProviderOptions {
+  endpoint: string;
+  initialSnapshot?: SiriusCapabilitySnapshot;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseCapabilitySnapshot(
+  payload: unknown,
+  providerID: string,
+): SiriusCapabilitySnapshot {
+  if (!isRecord(payload)) {
+    throw new Error("Capability endpoint returned an invalid response");
+  }
+
+  const principalPayload = isRecord(payload.principal)
+    ? payload.principal
+    : payload;
+  const subjectID = principalPayload.subjectId;
+  const displayName = principalPayload.displayName;
+  const capabilities = principalPayload.capabilities;
+
+  if (
+    typeof subjectID !== "string" ||
+    (typeof displayName !== "string" && displayName !== null) ||
+    !Array.isArray(capabilities) ||
+    !capabilities.every((capability) => typeof capability === "string")
+  ) {
+    throw new Error("Capability endpoint returned an invalid principal");
+  }
+
+  return {
+    principal: {
+      subjectId: subjectID,
+      displayName,
+      capabilities,
+    },
+    source: providerID,
+  };
+}
+
+/**
+ * Helper for a build-time extension that gets its capabilities from an API.
+ * The endpoint and its authorization policy remain outside Community.
+ */
+export function createApiCapabilityProvider({
+  endpoint,
+  initialSnapshot = communityCapabilitySnapshot,
+}: ApiCapabilityProviderOptions): SiriusCapabilityProviderDefinition {
+  const providerID = `api:${endpoint}`;
+
+  return {
+    id: providerID,
+    initialSnapshot,
+    load: async () => {
+      const response = await fetch(endpoint);
+      if (!response.ok) {
+        throw new Error(
+          `Capability endpoint returned HTTP ${response.status}`,
+        );
+      }
+
+      return parseCapabilitySnapshot(await response.json(), providerID);
+    },
+  };
+}

--- a/sirius-ui/src/ui/extensions/capabilities.tsx
+++ b/sirius-ui/src/ui/extensions/capabilities.tsx
@@ -111,8 +111,9 @@ interface SiriusCapabilityProviderProps {
  *
  * Community uses a static provider. A private build can supply a provider
  * whose `load` function reads its authenticated entitlement endpoint. A
- * failed load retains the provider's initial snapshot, which lets a Pro
- * provider fail closed by choosing an empty initial capability set.
+ * failed load retains the provider's initial snapshot. API-backed providers
+ * default that snapshot to an empty capability set so provider failures are
+ * fail-closed unless a caller explicitly supplies a different initial state.
  */
 export const SiriusCapabilityProvider = ({
   definition,
@@ -260,19 +261,37 @@ function parseCapabilitySnapshot(
   };
 }
 
+function createFailClosedCapabilitySnapshot(
+  providerID: string,
+): SiriusCapabilitySnapshot {
+  return {
+    principal: {
+      subjectId: "",
+      displayName: null,
+      capabilities: [],
+    },
+    source: providerID,
+  };
+}
+
 /**
  * Helper for a build-time extension that gets its capabilities from an API.
  * The endpoint and its authorization policy remain outside Community.
+ *
+ * API-backed providers default to an empty capability snapshot. If loading
+ * fails, the provider therefore remains fail-closed rather than inheriting
+ * the Community capability catalog.
  */
 export function createApiCapabilityProvider({
   endpoint,
-  initialSnapshot = communityCapabilitySnapshot,
+  initialSnapshot,
 }: ApiCapabilityProviderOptions): SiriusCapabilityProviderDefinition {
   const providerID = `api:${endpoint}`;
 
   return {
     id: providerID,
-    initialSnapshot,
+    initialSnapshot:
+      initialSnapshot ?? createFailClosedCapabilitySnapshot(providerID),
     load: async () => {
       const response = await fetch(endpoint);
       if (!response.ok) {

--- a/sirius-ui/src/ui/extensions/community.ts
+++ b/sirius-ui/src/ui/extensions/community.ts
@@ -1,0 +1,123 @@
+import AgentIcon from "~/components/icons/AgentIcon";
+import EnvironmentIcon from "~/components/icons/EnvironmentIcon";
+import ScanIcon from "~/components/icons/ScanIcon";
+import VulnerabilityIcon from "~/components/icons/VulnerabilityIcon";
+import type { SiriusUIExtension } from "./types";
+
+/**
+ * The public Community UI is itself an extension contribution. Keeping these
+ * declarations in the same registry as build-selected contributions lets a
+ * Pro image append navigation and guarded routes without editing Sidebar or
+ * Layout.
+ */
+export const communityUIExtension: SiriusUIExtension = {
+  id: "community.ui",
+  version: "1.0.0",
+  order: 0,
+  navigation: [
+    {
+      id: "community.scanner",
+      label: "Scanner",
+      href: "/scanner",
+      matchPaths: ["/scanner"],
+      icon: ScanIcon,
+      requiredCapabilities: ["ui.scanner"],
+      order: 10,
+    },
+    {
+      id: "community.vulnerabilities",
+      label: "Vulnerabilities",
+      href: "/vulnerabilities",
+      matchPaths: ["/vulnerabilities", "/vulnerability"],
+      icon: VulnerabilityIcon,
+      requiredCapabilities: ["ui.vulnerabilities"],
+      order: 20,
+    },
+    {
+      id: "community.environment",
+      label: "Environment",
+      href: "/environment",
+      matchPaths: ["/environment", "/host"],
+      icon: EnvironmentIcon,
+      requiredCapabilities: ["ui.environment"],
+      order: 30,
+    },
+    {
+      id: "community.terminal",
+      label: "Terminal",
+      href: "/terminal",
+      matchPaths: ["/terminal"],
+      icon: AgentIcon,
+      requiredCapabilities: ["ui.terminal"],
+      order: 40,
+    },
+  ],
+  routes: [
+    {
+      id: "community.dashboard",
+      path: "/dashboard",
+      requiredCapabilities: ["ui.dashboard_shell"],
+      order: 10,
+    },
+    {
+      id: "community.scanner",
+      path: "/scanner",
+      requiredCapabilities: ["ui.scanner"],
+      order: 20,
+    },
+    {
+      id: "community.vulnerabilities",
+      path: "/vulnerabilities",
+      requiredCapabilities: ["ui.vulnerabilities"],
+      order: 30,
+    },
+    {
+      id: "community.vulnerability",
+      path: "/vulnerability",
+      requiredCapabilities: ["ui.vulnerabilities"],
+      order: 40,
+    },
+    {
+      id: "community.environment",
+      path: "/environment",
+      requiredCapabilities: ["ui.environment"],
+      order: 50,
+    },
+    {
+      id: "community.host",
+      path: "/host",
+      requiredCapabilities: ["ui.environment"],
+      order: 60,
+    },
+    {
+      id: "community.terminal",
+      path: "/terminal",
+      requiredCapabilities: ["ui.terminal"],
+      order: 70,
+    },
+    {
+      id: "community.settings",
+      path: "/settings",
+      requiredCapabilities: ["ui.dashboard_shell"],
+      order: 80,
+    },
+    {
+      id: "community.system-monitor",
+      path: "/system-monitor",
+      requiredCapabilities: ["ui.dashboard_shell"],
+      order: 90,
+    },
+    {
+      id: "community.template-page",
+      path: "/template-page",
+      requiredCapabilities: ["ui.scanner"],
+      order: 100,
+    },
+    {
+      id: "community.finding",
+      path: "/finding",
+      requiredCapabilities: ["findings.vulnerabilities"],
+      order: 110,
+    },
+  ],
+};

--- a/sirius-ui/src/ui/extensions/index.ts
+++ b/sirius-ui/src/ui/extensions/index.ts
@@ -1,0 +1,12 @@
+import { communityUIExtension } from "./community";
+import { registeredUIExtensions } from "./registered";
+import { createUIExtensionRegistry } from "./registry";
+
+export * from "./capabilities";
+export * from "./registry";
+export * from "./types";
+
+export const uiExtensionRegistry = createUIExtensionRegistry([
+  communityUIExtension,
+  ...registeredUIExtensions,
+]);

--- a/sirius-ui/src/ui/extensions/registered.ts
+++ b/sirius-ui/src/ui/extensions/registered.ts
@@ -1,0 +1,10 @@
+import type { SiriusUIExtension } from "./types";
+
+/**
+ * Build-time extension slot.
+ *
+ * Community intentionally keeps this empty. A private build can overlay this
+ * module with a list of proprietary contributions without editing the
+ * canonical registry, Sidebar, Layout, or the Community declarations.
+ */
+export const registeredUIExtensions: readonly SiriusUIExtension[] = [];

--- a/sirius-ui/src/ui/extensions/registry.test.ts
+++ b/sirius-ui/src/ui/extensions/registry.test.ts
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import {
   CapabilityGate,
   SiriusCapabilityProvider,
+  createApiCapabilityProvider,
   createUIExtensionRegistry,
   hasRequiredCapabilities,
 } from "./index";
@@ -147,6 +148,29 @@ const hiddenGatedPage = renderToStaticMarkup(
 );
 assert.match(hiddenGatedPage, /hidden/);
 assert.doesNotMatch(hiddenGatedPage, /visible/);
+
+const apiCapabilityProvider = createApiCapabilityProvider({
+  endpoint: "/api/capabilities",
+});
+assert.equal(apiCapabilityProvider.initialSnapshot.principal.subjectId, "");
+assert.deepEqual(apiCapabilityProvider.initialSnapshot.principal.capabilities, []);
+
+const apiProviderFailClosedPage = renderToStaticMarkup(
+  React.createElement(
+    SiriusCapabilityProvider,
+    { definition: apiCapabilityProvider },
+    React.createElement(
+      CapabilityGate,
+      {
+        requiredCapabilities: ["reporting.enterprise"],
+        fallback: React.createElement("span", null, "hidden"),
+      },
+      React.createElement("span", null, "visible"),
+    ),
+  ),
+);
+assert.match(apiProviderFailClosedPage, /hidden/);
+assert.doesNotMatch(apiProviderFailClosedPage, /visible/);
 
 assert.throws(
   () =>

--- a/sirius-ui/src/ui/extensions/registry.test.ts
+++ b/sirius-ui/src/ui/extensions/registry.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  CapabilityGate,
+  SiriusCapabilityProvider,
+  createUIExtensionRegistry,
+  hasRequiredCapabilities,
+} from "./index";
+import type {
+  SiriusCapabilityProviderDefinition,
+  SiriusNavigationIcon,
+  SiriusUIExtension,
+} from "./types";
+
+const TestIcon: SiriusNavigationIcon = () => null;
+
+const community: SiriusUIExtension = {
+  id: "community",
+  version: "1.0.0",
+  order: 0,
+  navigation: [
+    {
+      id: "community.dashboard",
+      label: "Dashboard",
+      href: "/dashboard",
+      matchPaths: ["/dashboard"],
+      icon: TestIcon,
+      order: 10,
+    },
+  ],
+  routes: [
+    {
+      id: "community.dashboard",
+      path: "/dashboard",
+      requiredCapabilities: ["ui.dashboard_shell"],
+    },
+  ],
+};
+
+const reporting: SiriusUIExtension = {
+  id: "reporting",
+  version: "1.0.0",
+  navigation: [
+    {
+      id: "reporting.reports",
+      label: "Reports",
+      href: "/reports",
+      matchPaths: ["/reports"],
+      icon: TestIcon,
+      requiredCapabilities: ["reporting.enterprise"],
+    },
+  ],
+  routes: [
+    {
+      id: "reporting.reports",
+      path: "/reports",
+      requiredCapabilities: ["reporting.enterprise"],
+    },
+  ],
+};
+
+const registry = createUIExtensionRegistry([reporting, community]);
+
+assert.deepEqual(
+  registry.extensions.map((extension) => extension.id),
+  ["community", "reporting"],
+);
+assert.deepEqual(
+  registry.navigationItems.map((item) => item.id),
+  ["community.dashboard", "reporting.reports"],
+);
+assert.deepEqual(
+  registry.getRequiredCapabilitiesForPath("/reports/quarterly"),
+  ["reporting.enterprise"],
+);
+assert.equal(registry.getRouteForPath("/unknown"), undefined);
+
+assert.equal(
+  hasRequiredCapabilities(["reporting.enterprise"], [
+    "reporting.enterprise",
+  ]),
+  true,
+);
+assert.equal(
+  hasRequiredCapabilities(["reporting.enterprise"], [
+    "reporting.enterprise",
+    "reporting.scheduled",
+  ]),
+  false,
+);
+assert.equal(hasRequiredCapabilities([], []), true);
+
+const fakeCapabilityProvider: SiriusCapabilityProviderDefinition = {
+  id: "test",
+  initialSnapshot: {
+    principal: {
+      subjectId: "test-subject",
+      displayName: "Test",
+      capabilities: ["reporting.enterprise"],
+    },
+    source: "test",
+  },
+};
+
+const visibleGatedPage = renderToStaticMarkup(
+  React.createElement(
+    SiriusCapabilityProvider,
+    { definition: fakeCapabilityProvider },
+    React.createElement(
+      CapabilityGate,
+      {
+        requiredCapabilities: ["reporting.enterprise"],
+        fallback: React.createElement("span", null, "hidden"),
+      },
+      React.createElement("span", null, "visible"),
+    ),
+  ),
+);
+assert.match(visibleGatedPage, /visible/);
+assert.doesNotMatch(visibleGatedPage, /hidden/);
+
+const hiddenGatedPage = renderToStaticMarkup(
+  React.createElement(
+    SiriusCapabilityProvider,
+    {
+      definition: {
+        ...fakeCapabilityProvider,
+        initialSnapshot: {
+          ...fakeCapabilityProvider.initialSnapshot,
+          principal: {
+            ...fakeCapabilityProvider.initialSnapshot.principal,
+            capabilities: [],
+          },
+        },
+      },
+    },
+    React.createElement(
+      CapabilityGate,
+      {
+        requiredCapabilities: ["reporting.enterprise"],
+        fallback: React.createElement("span", null, "hidden"),
+      },
+      React.createElement("span", null, "visible"),
+    ),
+  ),
+);
+assert.match(hiddenGatedPage, /hidden/);
+assert.doesNotMatch(hiddenGatedPage, /visible/);
+
+assert.throws(
+  () =>
+    createUIExtensionRegistry([
+      community,
+      {
+        ...reporting,
+        id: "duplicate",
+        navigation: [
+          {
+            ...reporting.navigation![0]!,
+            id: "community.dashboard",
+          },
+        ],
+      },
+    ]),
+  /Duplicate navigation contribution id: community\.dashboard/,
+);
+
+assert.throws(
+  () =>
+    createUIExtensionRegistry([
+      community,
+      {
+        ...reporting,
+        id: "duplicate-path",
+        routes: [
+          {
+            ...reporting.routes![0]!,
+            id: "duplicate-path.route",
+            path: "/dashboard",
+          },
+        ],
+      },
+    ]),
+  /Duplicate UI route path: \/dashboard/,
+);
+
+console.log("UI extension registry contract tests passed");

--- a/sirius-ui/src/ui/extensions/registry.ts
+++ b/sirius-ui/src/ui/extensions/registry.ts
@@ -1,0 +1,184 @@
+import { communityCapabilityProvider } from "./capabilities";
+import type {
+  SiriusCapabilityProviderDefinition,
+  SiriusUIDashboardWidget,
+  SiriusUIExtension,
+  SiriusUINavigationItem,
+  SiriusUIRoute,
+  SiriusUISettingsPanel,
+} from "./types";
+
+export interface SiriusUIExtensionRegistry {
+  readonly extensions: readonly SiriusUIExtension[];
+  readonly navigationItems: readonly SiriusUINavigationItem[];
+  readonly routes: readonly SiriusUIRoute[];
+  readonly dashboardWidgets: readonly SiriusUIDashboardWidget[];
+  readonly settingsPanels: readonly SiriusUISettingsPanel[];
+  readonly capabilityProvider: SiriusCapabilityProviderDefinition;
+  getRouteForPath: (path: string) => SiriusUIRoute | undefined;
+  getRequiredCapabilitiesForPath: (
+    path: string,
+  ) => readonly string[];
+}
+
+const DEFAULT_EXTENSION_ORDER = 1000;
+
+function contributionOrder(
+  contribution: { order?: number; id: string },
+): number {
+  return contribution.order ?? DEFAULT_EXTENSION_ORDER;
+}
+
+function compareContributions(
+  left: { order?: number; id: string },
+  right: { order?: number; id: string },
+): number {
+  const orderDifference =
+    contributionOrder(left) - contributionOrder(right);
+  return orderDifference === 0
+    ? left.id.localeCompare(right.id)
+    : orderDifference;
+}
+
+function sorted<T extends { order?: number; id: string }>(
+  contributions: readonly T[],
+): readonly T[] {
+  return [...contributions].sort(compareContributions);
+}
+
+function requireNonEmpty(value: string, label: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`${label} must not be empty`);
+  }
+}
+
+function assertUnique<T extends { id: string }>(
+  contributions: readonly T[],
+  label: string,
+): void {
+  const seen = new Set<string>();
+  for (const contribution of contributions) {
+    requireNonEmpty(contribution.id, `${label} id`);
+    if (seen.has(contribution.id)) {
+      throw new Error(`Duplicate ${label} id: ${contribution.id}`);
+    }
+    seen.add(contribution.id);
+  }
+}
+
+function routePatterns(route: SiriusUIRoute): readonly string[] {
+  return route.matchPaths && route.matchPaths.length > 0
+    ? route.matchPaths
+    : [route.path];
+}
+
+function matchesPath(path: string, pattern: string): boolean {
+  return path === pattern || path.startsWith(`${pattern}/`);
+}
+
+function matchingPatternLength(
+  path: string,
+  route: SiriusUIRoute,
+): number | undefined {
+  const matchingPattern = routePatterns(route)
+    .filter((pattern) => matchesPath(path, pattern))
+    .sort((left, right) => right.length - left.length)[0];
+
+  return matchingPattern?.length;
+}
+
+function assertUniqueRoutePatterns(routes: readonly SiriusUIRoute[]): void {
+  const seen = new Set<string>();
+  for (const route of routes) {
+    requireNonEmpty(route.path, `Route ${route.id} path`);
+    for (const pattern of routePatterns(route)) {
+      requireNonEmpty(pattern, `Route ${route.id} path`);
+      if (seen.has(pattern)) {
+        throw new Error(`Duplicate UI route path: ${pattern}`);
+      }
+      seen.add(pattern);
+    }
+  }
+}
+
+/**
+ * Build the immutable compile-time UI registry.
+ *
+ * The caller supplies Community plus any build-selected extension
+ * contributions. Validation happens before the registry is exposed so a
+ * conflicting Pro overlay fails during build/startup instead of producing
+ * ambiguous navigation or route authorization at runtime.
+ */
+export function createUIExtensionRegistry(
+  extensions: readonly SiriusUIExtension[],
+): SiriusUIExtensionRegistry {
+  const orderedExtensions = sorted(extensions);
+  assertUnique(orderedExtensions, "UI extension");
+
+  const navigationItems = orderedExtensions.flatMap(
+    (extension) => extension.navigation ?? [],
+  );
+  const routes = orderedExtensions.flatMap(
+    (extension) => extension.routes ?? [],
+  );
+  const dashboardWidgets = orderedExtensions.flatMap(
+    (extension) => extension.dashboardWidgets ?? [],
+  );
+  const settingsPanels = orderedExtensions.flatMap(
+    (extension) => extension.settingsPanels ?? [],
+  );
+
+  assertUnique(navigationItems, "navigation contribution");
+  assertUnique(routes, "route contribution");
+  assertUnique(dashboardWidgets, "dashboard widget contribution");
+  assertUnique(settingsPanels, "settings panel contribution");
+  assertUniqueRoutePatterns(routes);
+
+  const capabilityProviders = orderedExtensions
+    .map((extension) => extension.capabilityProvider)
+    .filter(
+      (
+        provider,
+      ): provider is SiriusCapabilityProviderDefinition =>
+        provider !== undefined,
+    );
+
+  if (capabilityProviders.length > 1) {
+    throw new Error(
+      "Only one UI capability provider may be registered in a build",
+    );
+  }
+
+  const registry: SiriusUIExtensionRegistry = {
+    extensions: Object.freeze([...orderedExtensions]),
+    navigationItems: Object.freeze(sorted(navigationItems)),
+    routes: Object.freeze(sorted(routes)),
+    dashboardWidgets: Object.freeze(sorted(dashboardWidgets)),
+    settingsPanels: Object.freeze(sorted(settingsPanels)),
+    capabilityProvider:
+      capabilityProviders[0] ?? communityCapabilityProvider,
+    getRouteForPath: (path) => {
+      let bestMatch: SiriusUIRoute | undefined;
+      let bestLength = -1;
+
+      for (const route of routes) {
+        const currentLength = matchingPatternLength(path, route);
+        if (
+          currentLength !== undefined &&
+          currentLength > bestLength
+        ) {
+          bestMatch = route;
+          bestLength = currentLength;
+        }
+      }
+
+      return bestMatch;
+    },
+    getRequiredCapabilitiesForPath: (path) => {
+      const route = registry.getRouteForPath(path);
+      return route?.requiredCapabilities ?? [];
+    },
+  };
+
+  return Object.freeze(registry);
+}

--- a/sirius-ui/src/ui/extensions/types.ts
+++ b/sirius-ui/src/ui/extensions/types.ts
@@ -1,0 +1,82 @@
+import type React from "react";
+
+export type SiriusCapability = string;
+
+export interface SiriusPrincipal {
+  subjectId: string;
+  displayName?: string | null;
+  capabilities: readonly SiriusCapability[];
+}
+
+export interface SiriusCapabilitySnapshot {
+  principal: SiriusPrincipal;
+  source: string;
+}
+
+export interface SiriusCapabilityProviderDefinition {
+  id: string;
+  initialSnapshot: SiriusCapabilitySnapshot;
+  load?: () => Promise<SiriusCapabilitySnapshot>;
+}
+
+export interface SiriusNavigationIconProps {
+  className?: string;
+  width?: string | number;
+  height?: string | number;
+  stroke?: string;
+  fill?: string;
+}
+
+export type SiriusNavigationIcon = React.ComponentType<SiriusNavigationIconProps>;
+
+export interface SiriusUINavigationItem {
+  id: string;
+  label: string;
+  href: string;
+  matchPaths: readonly string[];
+  icon: SiriusNavigationIcon;
+  requiredCapabilities?: readonly SiriusCapability[];
+  order?: number;
+}
+
+export interface SiriusUIRoute {
+  id: string;
+  path: string;
+  matchPaths?: readonly string[];
+  requiredCapabilities?: readonly SiriusCapability[];
+  order?: number;
+}
+
+export interface SiriusUIDashboardWidget {
+  id: string;
+  title: string;
+  component: React.ComponentType;
+  requiredCapabilities?: readonly SiriusCapability[];
+  order?: number;
+}
+
+export interface SiriusUISettingsPanel {
+  id: string;
+  title: string;
+  component: React.ComponentType;
+  requiredCapabilities?: readonly SiriusCapability[];
+  order?: number;
+}
+
+/**
+ * A compile-time UI extension contribution.
+ *
+ * Community registers its own declarations, while a Pro build overlays
+ * `registered.ts` with additional declarations. The registry is assembled
+ * during module evaluation; no runtime plugin loading is involved.
+ */
+export interface SiriusUIExtension {
+  id: string;
+  version: string;
+  order?: number;
+  navigation?: readonly SiriusUINavigationItem[];
+  routes?: readonly SiriusUIRoute[];
+  dashboardWidgets?: readonly SiriusUIDashboardWidget[];
+  settingsPanels?: readonly SiriusUISettingsPanel[];
+  capabilityProvider?: SiriusCapabilityProviderDefinition;
+}

--- a/tasks/pro-bifurcation.json
+++ b/tasks/pro-bifurcation.json
@@ -196,7 +196,7 @@
         "title": "UI extension registry and capability provider",
         "description": "Build-time SiriusUIExtension registry; migrate Sidebar navigation and existing pages into registry declarations; add capability-aware rendering.",
         "details": "Registry supports routes, navigation, dashboard widgets, settings panels, requiredCapabilities. Capability provider context fed by API entitlement endpoint (Community provider returns community capabilities without any license). Pro UI image builds by cloning public sirius-ui at a pinned SHA and overlaying private extension modules, mirroring the engine pin pattern.",
-        "status": "in_progress",
+        "status": "done",
         "priority": "high",
         "dependencies": ["3.2"],
         "testStrategy": "Community UI renders identical navigation and pages from the registry (visual/E2E regression); a test extension adds a nav item and page gated by a fake capability."

--- a/tasks/pro-bifurcation.json
+++ b/tasks/pro-bifurcation.json
@@ -196,7 +196,7 @@
         "title": "UI extension registry and capability provider",
         "description": "Build-time SiriusUIExtension registry; migrate Sidebar navigation and existing pages into registry declarations; add capability-aware rendering.",
         "details": "Registry supports routes, navigation, dashboard widgets, settings panels, requiredCapabilities. Capability provider context fed by API entitlement endpoint (Community provider returns community capabilities without any license). Pro UI image builds by cloning public sirius-ui at a pinned SHA and overlaying private extension modules, mirroring the engine pin pattern.",
-        "status": "pending",
+        "status": "in_progress",
         "priority": "high",
         "dependencies": ["3.2"],
         "testStrategy": "Community UI renders identical navigation and pages from the registry (visual/E2E regression); a test extension adds a nav item and page gated by a fake capability."


### PR DESCRIPTION
## Summary

Implements Core Phase 3.4 and the UI-registry/capability-provider portion of **#147**: the public build-time UI extension foundation required for downstream extension consumers without embedding Pro product policy in Community.

This PR keeps Community independently runnable while replacing hard-coded UI composition with deterministic public extension contracts.

**Part of #147.** The broader #147 remains open for its server-side auth/tRPC extension seams; this PR should not close that issue automatically.

## What changed

### Build-time UI extension registry

Adds public extension contracts and registry support for:

- routes
- navigation contributions
- dashboard/widgets
- settings contributions
- deterministic ordering
- registration/collision validation

Community contributions are registered through the same public mechanism used by future build-time extensions.

### Neutral principal / capability layer

Adds a policy-neutral principal/capability provider suitable for Community defaults and downstream extension implementations.

Includes:

- capability-provider abstraction
- API-backed provider helper
- capability-gated rendering
- no `admin` / `student` / Pro role policy in the shared contract

This is an extension seam, not the multi-user feature implementation.

### Community migration to registry

Migrates existing Community UI composition to the registry, including the existing sidebar/routes, while preserving the current Community route experience.

### Tests and architecture documentation

Adds registry/collision and gated-rendering coverage, updates ADR-004 with the implemented extension seam, and marks Phase 3.4 complete in the bifurcation task tracker.

## Architectural invariants

This PR is expected to preserve the following boundaries:

- Community works with zero private extensions.
- Public contracts contain no Pro-specific role/user-management implementation.
- Extension registration is deterministic.
- Duplicate/colliding registrations fail deterministically rather than silently overriding Core contributions.
- Community route/navigation behavior remains available through the registry.
- Future private extensions should append through this seam rather than patching canonical `Sidebar.tsx`, `_app.tsx`, or related Core composition files.

## Validation performed

Passed by the implementation team:

- targeted ESLint
- UI extension registry tests
- gated-rendering tests
- documentation lint
- browser validation on all four Community routes

### Known unrelated diagnostics

Existing `ActiveConstellationV2Loader` TypeScript diagnostics remain. They pre-date and are unrelated to this change and should not be treated as a regression from this PR.

### Working-tree hygiene

A pre-existing local `sirius-ui/yarn.lock` modification was intentionally left untouched. It is **not included in this branch diff**.

### Current CI note

The current Community Independence / Core Manifest failures are from the existing leakage scanner detecting private-repository markers in unchanged `programs/complete-split-deploy-to-range/*` files. Those files are not part of this PR. The UI lint stage passes; remaining UI build CI should still complete before merge.

## Review focus

Please review especially for:

1. public extension API stability and naming;
2. deterministic ordering/collision semantics;
3. preservation of zero-extension Community behavior;
4. accidental product-policy leakage into principal/capability primitives;
5. whether future Pro UI modules can consume these seams without copying Core composition files;
6. tests that prove an extension cannot silently replace a Community contribution;
7. API-backed capability-provider failure behavior (see review note: private consumers should fail closed, not inherit Community capabilities on provider failure).

## Follow-on dependency

This is one of the foundation tasks in **#148**. Once the public UI interfaces are accepted/frozen, private multi-user identity/UI work can consume them. Server-side auth/tRPC extension work remains tracked by #147.