### PR TITLE
test(ui): exercise API capability-provider failure path

### DIFF
--- a/sirius-ui/src/ui/extensions/capabilities.tsx
+++ b/sirius-ui/src/ui/extensions/capabilities.tsx
@@ -77,6 +77,37 @@ export function hasRequiredCapabilities(
   return requiredCapabilities.every((capability) => available.has(capability));
 }
 
+export interface CapabilityLoadResult {
+  snapshot: SiriusCapabilitySnapshot;
+  error: Error | null;
+}
+
+/**
+ * Resolves a provider's capability snapshot, falling back to its initial
+ * snapshot when the provider fails. API-backed providers default that initial
+ * snapshot to an empty capability set, so a failed load denies capabilities
+ * instead of inheriting another edition's catalog.
+ */
+export async function loadCapabilitySnapshot(
+  definition: SiriusCapabilityProviderDefinition,
+): Promise<CapabilityLoadResult> {
+  if (!definition.load) {
+    return { snapshot: definition.initialSnapshot, error: null };
+  }
+
+  try {
+    return { snapshot: await definition.load(), error: null };
+  } catch (cause) {
+    return {
+      snapshot: definition.initialSnapshot,
+      error:
+        cause instanceof Error
+          ? cause
+          : new Error("Capability provider failed to load"),
+    };
+  }
+}
+
 interface CapabilityContextValue {
   principal: SiriusPrincipal;
   source: string;
@@ -136,28 +167,15 @@ export const SiriusCapabilityProvider = ({
       };
     }
 
-    void definition
-      .load()
-      .then((nextSnapshot) => {
-        if (!active) {
-          return;
-        }
+    void loadCapabilitySnapshot(definition).then((result) => {
+      if (!active) {
+        return;
+      }
 
-        setSnapshot(nextSnapshot);
-        setLoading(false);
-      })
-      .catch((cause: unknown) => {
-        if (!active) {
-          return;
-        }
-
-        setError(
-          cause instanceof Error
-            ? cause
-            : new Error("Capability provider failed to load"),
-        );
-        setLoading(false);
-      });
+      setSnapshot(result.snapshot);
+      setError(result.error);
+      setLoading(false);
+    });
 
     return () => {
       active = false;

--- a/sirius-ui/src/ui/extensions/registry.test.ts
+++ b/sirius-ui/src/ui/extensions/registry.test.ts
@@ -7,6 +7,7 @@ import {
   createApiCapabilityProvider,
   createUIExtensionRegistry,
   hasRequiredCapabilities,
+  loadCapabilitySnapshot,
 } from "./index";
 import type {
   SiriusCapabilityProviderDefinition,
@@ -172,6 +173,79 @@ const apiProviderFailClosedPage = renderToStaticMarkup(
 assert.match(apiProviderFailClosedPage, /hidden/);
 assert.doesNotMatch(apiProviderFailClosedPage, /visible/);
 
+async function assertFailedCapabilityRequestDeniesContributions(
+  label: string,
+  fetchImplementation: typeof fetch,
+): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = fetchImplementation;
+
+  try {
+    const result = await loadCapabilitySnapshot(
+      createApiCapabilityProvider({ endpoint: "/api/capabilities" }),
+    );
+
+    assert.ok(result.error instanceof Error, `${label}: expected an error`);
+    assert.deepEqual(
+      result.snapshot.principal.capabilities,
+      [],
+      `${label}: expected an empty capability set`,
+    );
+    assert.equal(
+      hasRequiredCapabilities(result.snapshot.principal.capabilities, [
+        "reporting.enterprise",
+      ]),
+      false,
+      `${label}: expected the capability check to deny`,
+    );
+
+    const deniedPage = renderToStaticMarkup(
+      React.createElement(
+        SiriusCapabilityProvider,
+        { definition: { id: "api-failure", initialSnapshot: result.snapshot } },
+        React.createElement(
+          CapabilityGate,
+          {
+            requiredCapabilities: ["reporting.enterprise"],
+            fallback: React.createElement("span", null, "hidden"),
+          },
+          React.createElement("span", null, "visible"),
+        ),
+      ),
+    );
+
+    assert.match(deniedPage, /hidden/, `${label}: expected the fallback`);
+    assert.doesNotMatch(
+      deniedPage,
+      /visible/,
+      `${label}: expected no gated content`,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+async function assertApiCapabilityProviderFailsClosed(): Promise<void> {
+  await assertFailedCapabilityRequestDeniesContributions("network failure", () =>
+    Promise.reject(new Error("network unreachable")),
+  );
+
+  await assertFailedCapabilityRequestDeniesContributions("HTTP error", () =>
+    Promise.resolve(new Response("nope", { status: 503 })),
+  );
+
+  await assertFailedCapabilityRequestDeniesContributions(
+    "malformed payload",
+    () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ principal: { subjectId: 42 } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+  );
+}
+
 assert.throws(
   () =>
     createUIExtensionRegistry([
@@ -209,4 +283,11 @@ assert.throws(
   /Duplicate UI route path: \/dashboard/,
 );
 
-console.log("UI extension registry contract tests passed");
+assertApiCapabilityProviderFailsClosed()
+  .then(() => {
+    console.log("UI extension registry contract tests passed");
+  })
+  .catch((cause: unknown) => {
+    console.error(cause);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Follow-up to #149. The merged fail-closed default was correct, but the original regression assertion only verified the provider's pre-load initial snapshot. Because `renderToStaticMarkup` does not execute React effects, that test could not detect a regression in the asynchronous provider failure/catch path.

This PR makes the actual load/fallback path directly testable and verifies that API-backed capability providers remain fail-closed on real endpoint failures.

Part of #147.

## Changes

- Extract `loadCapabilitySnapshot(definition)` from `SiriusCapabilityProvider`'s effect.
- The provider effect now calls the same helper exercised by contract tests.
- Preserve the existing empty default snapshot for API-backed providers.
- Add failure-path coverage for:
  - rejected/network request;
  - HTTP 503;
  - malformed principal payload.
- For every failure case, assert:
  - an error is surfaced;
  - resulting capabilities are empty;
  - `reporting.enterprise` is denied;
  - gated content renders its fallback rather than protected content.

## Architectural invariant

An unavailable or malformed external capability source must not broaden authority or inherit the Community capability catalog.

```text
API capability load failure
        -> error surfaced
        -> initial fail-closed snapshot retained
        -> protected capability denied
```

## Scope

Only two files differ from current `main`:

- `sirius-ui/src/ui/extensions/capabilities.tsx`
- `sirius-ui/src/ui/extensions/registry.test.ts`

No product policy, role model, route behavior, or private dependency is introduced.

## Validation reported by implementation team

- targeted TypeScript check: no diagnostics under `src/ui/extensions`;
- targeted ESLint clean for extension files, Sidebar, Layout, and `_app`;
- failure test verified to have teeth by temporarily restoring the permissive default and observing failure.

Known repository-wide baseline TypeScript/lint issues outside these files remain unrelated.