### PR TITLE
feat(server): add principal authorization and tRPC extension seams

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,12 @@ jobs:
         run: npm run lint
         working-directory: sirius-ui
 
+      # Blocking: these guard the capability catalog and the UI/server extension
+      # contracts that private builds overlay.
+      - name: Run extension contract tests
+        run: npm run test:extensions
+        working-directory: sirius-ui
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/documentation/dev/architecture/ADR.004-extension-contracts.md
+++ b/documentation/dev/architecture/ADR.004-extension-contracts.md
@@ -79,9 +79,19 @@ Today the API registers Fiber routes through a `RouteSetter` interface wired in 
   namespace, so a contributed namespace is authorized without the contribution
   patching Core procedures. Principal resolution fails closed: a resolver that
   throws yields no principal, and every gated procedure is denied rather than
-  inheriting another edition's capabilities. Community resolves any
-  authenticated session to its static catalog, which leaves Community behavior
-  unchanged.
+  inheriting another edition's capabilities.
+- The single resolver slot is a replacement, not a competition. Community
+  declares no resolver contribution, so the slot stays open and one
+  build-selected resolver becomes authoritative; with no contribution the
+  registry falls back to `communityPrincipalResolver`, which resolves any
+  authenticated session to the static Community catalog. Community behavior with
+  zero extensions is therefore unchanged, and an extended build replaces
+  resolution without editing Community declarations.
+- The server extension contract surface is frozen at v1: `SiriusServerExtension`,
+  `SiriusPrincipalResolver`, `SiriusSessionEnricher`, the `registered.ts` exports,
+  and the capability primitives in `src/contracts/capabilities.ts`. Later changes
+  must be additive and justified by a concrete consumer failure rather than
+  anticipated need.
 - Community `/api/v1` OpenAPI, route classification, and reserved-namespace policy live in
   [README.api-openapi-contract.md](README.api-openapi-contract.md) and
   `sirius-api/contracts/`.

--- a/documentation/dev/architecture/ADR.004-extension-contracts.md
+++ b/documentation/dev/architecture/ADR.004-extension-contracts.md
@@ -61,6 +61,27 @@ Today the API registers Fiber routes through a `RouteSetter` interface wired in 
   checks to shared components; Community uses its static public capability
   catalog, while a private build may supply an API-backed provider without
   changing `Sidebar.tsx` or `Layout.tsx`.
+- The neutral capability and principal primitives shared by the browser and the
+  server live in `sirius-ui/src/contracts/capabilities.ts`. Both registries import
+  that module so the informative UI gating catalog and the authoritative
+  server-side enforcement catalog cannot drift; a contract test pins the
+  Community catalog to `documentation/product/edition-boundary.yaml`.
+- The server registry lives under `sirius-ui/src/server/extensions/`. A
+  `SiriusServerExtension` declares tRPC namespaces with their
+  `requiredCapabilities`, at most one `SiriusPrincipalResolver`, and optional
+  session enrichers. `registered.ts` is the build-time overlay: its
+  `registeredServerExtensions` carry the declarations the registry validates,
+  while `registeredServerRouters` carries the routers as an object literal so
+  spreading them into `root.ts` preserves tRPC client type inference. `root.ts`
+  cross-checks the two, so a router without a declared namespace (or a declared
+  namespace with no router) fails at startup.
+- `protectedProcedure` enforces the capabilities declared for the procedure's
+  namespace, so a contributed namespace is authorized without the contribution
+  patching Core procedures. Principal resolution fails closed: a resolver that
+  throws yields no principal, and every gated procedure is denied rather than
+  inheriting another edition's capabilities. Community resolves any
+  authenticated session to its static catalog, which leaves Community behavior
+  unchanged.
 - Community `/api/v1` OpenAPI, route classification, and reserved-namespace policy live in
   [README.api-openapi-contract.md](README.api-openapi-contract.md) and
   `sirius-api/contracts/`.

--- a/documentation/dev/architecture/ADR.004-extension-contracts.md
+++ b/documentation/dev/architecture/ADR.004-extension-contracts.md
@@ -69,12 +69,18 @@ Today the API registers Fiber routes through a `RouteSetter` interface wired in 
 - The server registry lives under `sirius-ui/src/server/extensions/`. A
   `SiriusServerExtension` declares tRPC namespaces with their
   `requiredCapabilities`, at most one `SiriusPrincipalResolver`, and optional
-  session enrichers. `registered.ts` is the build-time overlay: its
-  `registeredServerExtensions` carry the declarations the registry validates,
-  while `registeredServerRouters` carries the routers as an object literal so
-  spreading them into `root.ts` preserves tRPC client type inference. `root.ts`
+  session enrichers. There are two build-time overlay modules:
+  `registered.ts` carries the declarations the registry validates, and
+  `registered-routers.ts` carries the routers as an object literal so spreading
+  them into `root.ts` preserves tRPC client type inference. `root.ts`
   cross-checks the two, so a router without a declared namespace (or a declared
   namespace with no router) fails at startup.
+- The two overlay modules are separate because `trpc.ts` imports the registry to
+  enforce capabilities, while router modules import `createTRPCRouter` from
+  `trpc.ts`. Declaring both in one module cycles, and the overlay's routers then
+  fail at load with `Cannot access 'createTRPCRouter' before initialization`. No
+  module reachable from `registered.ts` may import `~/server/api/trpc`; a
+  contract test enforces that on the Core modules.
 - `protectedProcedure` enforces the capabilities declared for the procedure's
   namespace, so a contributed namespace is authorized without the contribution
   patching Core procedures. Principal resolution fails closed: a resolver that
@@ -88,8 +94,9 @@ Today the API registers Fiber routes through a `RouteSetter` interface wired in 
   zero extensions is therefore unchanged, and an extended build replaces
   resolution without editing Community declarations.
 - The server extension contract surface is frozen at v1: `SiriusServerExtension`,
-  `SiriusPrincipalResolver`, `SiriusSessionEnricher`, the `registered.ts` exports,
-  and the capability primitives in `src/contracts/capabilities.ts`. Later changes
+  `SiriusPrincipalResolver`, `SiriusSessionEnricher`, the `registered.ts` and
+  `registered-routers.ts` exports, and the capability primitives in
+  `src/contracts/capabilities.ts`. Later changes
   must be additive and justified by a concrete consumer failure rather than
   anticipated need.
 - Community `/api/v1` OpenAPI, route classification, and reserved-namespace policy live in

--- a/sirius-ui/package.json
+++ b/sirius-ui/package.json
@@ -7,7 +7,10 @@
     "dev": "npx next dev",
     "postinstall": "npx prisma generate",
     "lint": "npx lint",
+    "test:capabilities": "tsx src/contracts/capabilities.test.ts",
     "test:ui-extensions": "tsx src/ui/extensions/registry.test.ts",
+    "test:server-extensions": "tsx src/server/extensions/registry.test.ts",
+    "test:extensions": "npm run test:capabilities && npm run test:ui-extensions && npm run test:server-extensions",
     "start": "npx next start"
   },
   "dependencies": {

--- a/sirius-ui/src/contracts/capabilities.test.ts
+++ b/sirius-ui/src/contracts/capabilities.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  COMMUNITY_CAPABILITIES,
+  anonymousPrincipal,
+  communityPrincipal,
+  hasRequiredCapabilities,
+  missingCapabilities,
+} from "./capabilities";
+
+const EDITION_BOUNDARY = path.join(
+  __dirname,
+  "../../../documentation/product/edition-boundary.yaml",
+);
+
+/**
+ * Reads the community capability names out of the edition boundary file.
+ *
+ * The file is a flat two-level map, so this stays a deliberately small reader
+ * rather than pulling a YAML parser into the UI dependency tree.
+ */
+function communityCapabilitiesFromEditionBoundary(): readonly string[] {
+  const lines = readFileSync(EDITION_BOUNDARY, "utf8").split("\n");
+  const capabilities: string[] = [];
+  let inCapabilities = false;
+  let currentCapability: string | null = null;
+
+  for (const line of lines) {
+    if (/^capabilities:\s*$/.test(line)) {
+      inCapabilities = true;
+      continue;
+    }
+
+    if (!inCapabilities) {
+      continue;
+    }
+
+    if (/^\S/.test(line)) {
+      break;
+    }
+
+    const capabilityMatch = /^ {2}([A-Za-z0-9_.]+):\s*$/.exec(line);
+    if (capabilityMatch) {
+      currentCapability = capabilityMatch[1] ?? null;
+      continue;
+    }
+
+    if (
+      currentCapability !== null &&
+      /^ {4}edition:\s*community\s*$/.test(line)
+    ) {
+      capabilities.push(currentCapability);
+      currentCapability = null;
+    }
+  }
+
+  return capabilities;
+}
+
+const documented = communityCapabilitiesFromEditionBoundary();
+
+assert.ok(
+  documented.length > 0,
+  "failed to read community capabilities from the edition boundary file",
+);
+assert.deepEqual(
+  [...COMMUNITY_CAPABILITIES].sort(),
+  [...documented].sort(),
+  "COMMUNITY_CAPABILITIES has drifted from documentation/product/edition-boundary.yaml",
+);
+assert.deepEqual(communityPrincipal.capabilities, COMMUNITY_CAPABILITIES);
+
+assert.deepEqual(anonymousPrincipal.capabilities, []);
+assert.equal(hasRequiredCapabilities(anonymousPrincipal.capabilities, []), true);
+assert.equal(
+  hasRequiredCapabilities(anonymousPrincipal.capabilities, ["api.hosts"]),
+  false,
+);
+assert.deepEqual(missingCapabilities(null, ["api.hosts", "api.events"]), [
+  "api.hosts",
+  "api.events",
+]);
+assert.deepEqual(missingCapabilities(communityPrincipal, ["api.hosts"]), []);
+assert.deepEqual(
+  missingCapabilities(communityPrincipal, [
+    "api.hosts",
+    "reporting.enterprise",
+  ]),
+  ["reporting.enterprise"],
+);
+
+console.log("Capability contract tests passed");

--- a/sirius-ui/src/contracts/capabilities.ts
+++ b/sirius-ui/src/contracts/capabilities.ts
@@ -1,0 +1,120 @@
+/**
+ * Neutral capability and principal contracts.
+ *
+ * These primitives are shared by the browser registry (`~/ui/extensions`) and
+ * the server registry (`~/server/extensions`), so this module must stay free of
+ * React and of any server-only import. Keeping one definition here prevents the
+ * informative UI gating catalog and the authoritative server enforcement
+ * catalog from drifting apart.
+ *
+ * A capability is an opaque string. Core never interprets it as a role, a
+ * license tier, or an edition name.
+ */
+
+export type SiriusCapability = string;
+
+/**
+ * An opaque subject plus the capabilities it currently holds.
+ *
+ * Core does not know whether a subject is an operator, a service account, or a
+ * member of some private tenancy model. Only the resolving edition does.
+ */
+export interface SiriusPrincipal {
+  subjectId: string;
+  displayName?: string | null;
+  capabilities: readonly SiriusCapability[];
+}
+
+export interface SiriusCapabilitySnapshot {
+  principal: SiriusPrincipal;
+  source: string;
+}
+
+export interface SiriusCapabilityProviderDefinition {
+  id: string;
+  initialSnapshot: SiriusCapabilitySnapshot;
+  load?: () => Promise<SiriusCapabilitySnapshot>;
+}
+
+/**
+ * Community capabilities are available without a license or entitlement
+ * service. Keep this list aligned with the community entries in
+ * `documentation/product/edition-boundary.yaml`, which is the source of truth.
+ */
+export const COMMUNITY_CAPABILITIES: readonly SiriusCapability[] = [
+  "scanning.core",
+  "inventory.hosts",
+  "findings.vulnerabilities",
+  "api.public_rest",
+  "ui.dashboard_shell",
+  "auth.local_users",
+  "auth.api_keys",
+  "messaging.queues",
+  "storage.postgres_core",
+  "storage.valkey",
+  "migrations.core",
+  "extensions.module_registry",
+  "ui.scanner",
+  "ui.vulnerabilities",
+  "ui.environment",
+  "ui.terminal",
+  "api.hosts",
+  "api.vulnerabilities",
+  "api.templates",
+  "api.agent_templates",
+  "api.events",
+  "api.snapshots",
+  "api.statistics",
+  "api.scan_control",
+  "engine.scanner",
+  "engine.agent_runtime",
+  "agents.remote",
+  "reporting.basic_export",
+];
+
+export const communityPrincipal: SiriusPrincipal = {
+  subjectId: "community",
+  displayName: "Community",
+  capabilities: COMMUNITY_CAPABILITIES,
+};
+
+export const communityCapabilitySnapshot: SiriusCapabilitySnapshot = {
+  principal: communityPrincipal,
+  source: "community",
+};
+
+/**
+ * The principal used when no capability source could be established. It holds
+ * nothing, so every gated contribution is denied.
+ */
+export const anonymousPrincipal: SiriusPrincipal = {
+  subjectId: "",
+  displayName: null,
+  capabilities: [],
+};
+
+export function hasRequiredCapabilities(
+  availableCapabilities: readonly SiriusCapability[],
+  requiredCapabilities: readonly SiriusCapability[] = [],
+): boolean {
+  if (requiredCapabilities.length === 0) {
+    return true;
+  }
+
+  const available = new Set(availableCapabilities);
+  return requiredCapabilities.every((capability) => available.has(capability));
+}
+
+/**
+ * Returns the required capabilities the principal does not hold. A missing
+ * principal holds nothing, so every required capability is reported.
+ */
+export function missingCapabilities(
+  principal: SiriusPrincipal | null,
+  requiredCapabilities: readonly SiriusCapability[] = [],
+): readonly SiriusCapability[] {
+  const available = new Set(principal?.capabilities ?? []);
+  return requiredCapabilities.filter(
+    (capability) => !available.has(capability),
+  );
+}

--- a/sirius-ui/src/server/api/root.ts
+++ b/sirius-ui/src/server/api/root.ts
@@ -16,13 +16,19 @@ import { agentScanRouter } from "~/server/api/routers/agentScan";
 import { apikeysRouter } from "~/server/api/routers/apikeys";
 import { logsRouter } from "~/server/api/routers/logs";
 import { createTRPCRouter } from "~/server/api/trpc";
+import {
+  registeredServerRouters,
+  serverExtensionRegistry,
+} from "~/server/extensions";
 
 /**
  * This is the primary router for your server.
  *
- * All routers added in /api/routers should be manually added here.
+ * Community routers are listed here; a private build contributes additional
+ * namespaces through `registeredServerRouters`. Both are spread as object
+ * literals so tRPC keeps inferring the client-side types for every namespace.
  */
-export const appRouter = createTRPCRouter({
+const routers = {
   host: hostRouter,
   vulnerability: vulnerabilityRouter,
   store: storeRouter,
@@ -40,7 +46,16 @@ export const appRouter = createTRPCRouter({
   agentScan: agentScanRouter,
   apikeys: apikeysRouter,
   logs: logsRouter,
-});
+  ...registeredServerRouters,
+};
+
+// Every composed namespace must be declared by a server extension, and every
+// declared namespace must be composed. This rejects an overlay that ships a
+// router without declaring its capability requirements, or declares a namespace
+// it never serves, at startup rather than at request time.
+serverExtensionRegistry.assertRouterNamespaces(Object.keys(routers));
+
+export const appRouter = createTRPCRouter(routers);
 
 // export type definition of API
 export type AppRouter = typeof appRouter;

--- a/sirius-ui/src/server/api/root.ts
+++ b/sirius-ui/src/server/api/root.ts
@@ -16,10 +16,8 @@ import { agentScanRouter } from "~/server/api/routers/agentScan";
 import { apikeysRouter } from "~/server/api/routers/apikeys";
 import { logsRouter } from "~/server/api/routers/logs";
 import { createTRPCRouter } from "~/server/api/trpc";
-import {
-  registeredServerRouters,
-  serverExtensionRegistry,
-} from "~/server/extensions";
+import { serverExtensionRegistry } from "~/server/extensions";
+import { registeredServerRouters } from "~/server/extensions/registered-routers";
 
 /**
  * This is the primary router for your server.

--- a/sirius-ui/src/server/api/trpc.ts
+++ b/sirius-ui/src/server/api/trpc.ts
@@ -14,6 +14,13 @@ import superjson from "superjson";
 import { ZodError } from "zod";
 import { getServerAuthSession } from "~/server/auth";
 import { prisma } from "~/server/db";
+import type { SiriusCapability, SiriusPrincipal } from "~/contracts/capabilities";
+import {
+  SiriusCapabilityError,
+  assertPrincipalCapabilities,
+  resolvePrincipal,
+  serverExtensionRegistry,
+} from "~/server/extensions";
 
 /**
  * 1. CONTEXT
@@ -25,6 +32,7 @@ import { prisma } from "~/server/db";
 
 interface CreateContextOptions {
   session: Session | null;
+  principal?: SiriusPrincipal | null;
 }
 
 /**
@@ -37,9 +45,10 @@ interface CreateContextOptions {
  *
  * @see https://create.t3.gg/en/usage/trpc#-serverapitrpcts
  */
-const createInnerTRPCContext = (opts: CreateContextOptions) => {
+export const createInnerTRPCContext = (opts: CreateContextOptions) => {
   return {
     session: opts.session,
+    principal: opts.principal ?? null,
     prisma,
   };
 };
@@ -56,8 +65,17 @@ export const createTRPCContext = async (opts: CreateNextContextOptions) => {
   // Get the session from the server using the getServerSession wrapper function
   const session = await getServerAuthSession({ req, res });
 
+  // The registered principal resolver decides which subject is calling and
+  // which capabilities it holds. It fails closed, so an unresolved principal
+  // reaches the procedures with no capabilities at all.
+  const principal = await resolvePrincipal(
+    serverExtensionRegistry.principalResolver,
+    { session },
+  );
+
   return {
     session,
+    principal,
     prisma,
   };
 };
@@ -120,12 +138,61 @@ const enforceUserIsAuthed = t.middleware(({ ctx, next }) => {
   });
 });
 
+function assertCapabilities(
+  principal: SiriusPrincipal | null,
+  requiredCapabilities: readonly SiriusCapability[],
+): void {
+  try {
+    assertPrincipalCapabilities(principal, requiredCapabilities);
+  } catch (cause) {
+    if (cause instanceof SiriusCapabilityError) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message: cause.message,
+        cause,
+      });
+    }
+
+    throw cause;
+  }
+}
+
+/**
+ * Enforces the capabilities the registry declares for the procedure's
+ * namespace. Community declares its own namespaces, so a Community operator is
+ * unaffected, while a namespace contributed by an extension is authorized
+ * without that extension patching Core procedures.
+ */
+const enforceNamespaceCapabilities = t.middleware(({ ctx, path, next }) => {
+  assertCapabilities(
+    ctx.principal,
+    serverExtensionRegistry.getRequiredCapabilitiesForProcedure(path),
+  );
+
+  return next();
+});
+
 /**
  * Protected (authenticated) procedure
  *
  * If you want a query or mutation to ONLY be accessible to logged in users, use this. It verifies
- * the session is valid and guarantees `ctx.session.user` is not null.
+ * the session is valid and guarantees `ctx.session.user` is not null. It also enforces the
+ * capabilities declared for the procedure's namespace.
  *
  * @see https://trpc.io/docs/procedures
  */
-export const protectedProcedure = t.procedure.use(enforceUserIsAuthed);
+export const protectedProcedure = t.procedure
+  .use(enforceUserIsAuthed)
+  .use(enforceNamespaceCapabilities);
+
+/**
+ * Protected procedure with additional explicit capability requirements, for
+ * procedures that need more than their namespace declares.
+ */
+export const capabilityProcedure = (
+  ...requiredCapabilities: SiriusCapability[]
+) =>
+  protectedProcedure.use(({ ctx, next }) => {
+    assertCapabilities(ctx.principal, requiredCapabilities);
+    return next();
+  });

--- a/sirius-ui/src/server/auth.ts
+++ b/sirius-ui/src/server/auth.ts
@@ -9,6 +9,11 @@ import CredentialsProvider from "next-auth/providers/credentials";
 
 import { env } from "~/env.mjs";
 import { prisma } from "~/server/db";
+import {
+  applySessionEnrichers,
+  resolvePrincipal,
+  serverExtensionRegistry,
+} from "~/server/extensions";
 import bcrypt from "bcrypt";
 
 /**
@@ -70,11 +75,28 @@ export const authOptions: NextAuthOptions = {
     maxAge: 100 * 365 * 24 * 60 * 60, // 100 years in seconds - effectively indefinite
   },
   callbacks: {
-    session({ session, token }) {
+    async session({ session, token }) {
       if (session.user && token.sub) {
         session.user.id = token.sub;
       }
-      return session;
+
+      // Registered extensions may publish their own principal data on the
+      // session. Community registers no enricher, so the session is returned
+      // unchanged.
+      if (serverExtensionRegistry.sessionEnrichers.length === 0) {
+        return session;
+      }
+
+      const principal = await resolvePrincipal(
+        serverExtensionRegistry.principalResolver,
+        { session },
+      );
+
+      return applySessionEnrichers(
+        serverExtensionRegistry.sessionEnrichers,
+        session,
+        principal,
+      );
     },
     // Fix redirect callback to use proper URL
     async redirect({ url, baseUrl }) {

--- a/sirius-ui/src/server/extensions/community.ts
+++ b/sirius-ui/src/server/extensions/community.ts
@@ -1,4 +1,3 @@
-import { communityPrincipalResolver } from "./principal";
 import type { SiriusServerExtension } from "./types";
 
 /**
@@ -8,12 +7,17 @@ import type { SiriusServerExtension } from "./types";
  * with the capability a caller needs to reach it. Capability names come from
  * `documentation/product/edition-boundary.yaml`; this file must not invent new
  * ones.
+ *
+ * Community does not register a principal resolver contribution. The server
+ * registry falls back to `communityPrincipalResolver` when no extension
+ * supplies one. That keeps zero-extension Community behavior unchanged while
+ * allowing exactly one build-selected resolver to become authoritative in an
+ * extended distribution.
  */
 export const communityServerExtension: SiriusServerExtension = {
   id: "community.server",
   version: "1.0.0",
   order: 0,
-  principalResolver: communityPrincipalResolver,
   routerNamespaces: [
     { namespace: "host", requiredCapabilities: ["api.hosts"] },
     {

--- a/sirius-ui/src/server/extensions/community.ts
+++ b/sirius-ui/src/server/extensions/community.ts
@@ -1,0 +1,45 @@
+import { communityPrincipalResolver } from "./principal";
+import type { SiriusServerExtension } from "./types";
+
+/**
+ * Community's server contributions.
+ *
+ * Every namespace merged into the application router is declared here, together
+ * with the capability a caller needs to reach it. Capability names come from
+ * `documentation/product/edition-boundary.yaml`; this file must not invent new
+ * ones.
+ */
+export const communityServerExtension: SiriusServerExtension = {
+  id: "community.server",
+  version: "1.0.0",
+  order: 0,
+  principalResolver: communityPrincipalResolver,
+  routerNamespaces: [
+    { namespace: "host", requiredCapabilities: ["api.hosts"] },
+    {
+      namespace: "vulnerability",
+      requiredCapabilities: ["api.vulnerabilities"],
+    },
+    { namespace: "store", requiredCapabilities: ["storage.valkey"] },
+    { namespace: "queue", requiredCapabilities: ["messaging.queues"] },
+    { namespace: "user", requiredCapabilities: ["auth.local_users"] },
+    { namespace: "terminal", requiredCapabilities: ["ui.terminal"] },
+    { namespace: "agent", requiredCapabilities: ["agents.remote"] },
+    { namespace: "scanner", requiredCapabilities: ["api.scan_control"] },
+    { namespace: "templates", requiredCapabilities: ["api.templates"] },
+    { namespace: "scripts", requiredCapabilities: ["engine.scanner"] },
+    {
+      namespace: "agentTemplates",
+      requiredCapabilities: ["api.agent_templates"],
+    },
+    {
+      namespace: "repositories",
+      requiredCapabilities: ["api.agent_templates"],
+    },
+    { namespace: "statistics", requiredCapabilities: ["api.statistics"] },
+    { namespace: "events", requiredCapabilities: ["api.events"] },
+    { namespace: "agentScan", requiredCapabilities: ["engine.agent_runtime"] },
+    { namespace: "apikeys", requiredCapabilities: ["auth.api_keys"] },
+    { namespace: "logs", requiredCapabilities: ["api.events"] },
+  ],
+};

--- a/sirius-ui/src/server/extensions/index.ts
+++ b/sirius-ui/src/server/extensions/index.ts
@@ -1,0 +1,14 @@
+import { communityServerExtension } from "./community";
+import { registeredServerExtensions } from "./registered";
+import { createServerExtensionRegistry } from "./registry";
+
+export * from "./principal";
+export * from "./registry";
+export * from "./types";
+export { communityServerExtension } from "./community";
+export { registeredServerRouters } from "./registered";
+
+export const serverExtensionRegistry = createServerExtensionRegistry([
+  communityServerExtension,
+  ...registeredServerExtensions,
+]);

--- a/sirius-ui/src/server/extensions/index.ts
+++ b/sirius-ui/src/server/extensions/index.ts
@@ -6,7 +6,6 @@ export * from "./principal";
 export * from "./registry";
 export * from "./types";
 export { communityServerExtension } from "./community";
-export { registeredServerRouters } from "./registered";
 
 export const serverExtensionRegistry = createServerExtensionRegistry([
   communityServerExtension,

--- a/sirius-ui/src/server/extensions/principal.ts
+++ b/sirius-ui/src/server/extensions/principal.ts
@@ -1,0 +1,114 @@
+import {
+  COMMUNITY_CAPABILITIES,
+  missingCapabilities,
+} from "~/contracts/capabilities";
+import type { SiriusCapability, SiriusPrincipal } from "~/contracts/capabilities";
+import type {
+  SiriusPrincipalResolutionInput,
+  SiriusPrincipalResolver,
+  SiriusSessionEnricher,
+} from "./types";
+import type { Session } from "next-auth";
+
+/**
+ * Raised when the resolved principal does not hold every required capability.
+ *
+ * The structured `code` and `missing` fields let transport layers translate the
+ * denial without re-deriving it. Licensing denials are a separate concern and
+ * will carry their own code once the entitlement provider lands.
+ */
+export class SiriusCapabilityError extends Error {
+  readonly code = "CAPABILITY_REQUIRED";
+  readonly missing: readonly SiriusCapability[];
+
+  constructor(missing: readonly SiriusCapability[]) {
+    super(`Missing required capabilities: ${missing.join(", ")}`);
+    this.name = "SiriusCapabilityError";
+    this.missing = missing;
+  }
+}
+
+/**
+ * Community's resolver: any authenticated session holds the Community catalog,
+ * and an unauthenticated request holds nothing.
+ *
+ * Community is a single-operator deployment, so it does not differentiate
+ * subjects. The subject id is still carried through so that shared code paths
+ * behave identically once a private resolver supplies real subjects.
+ */
+export const communityPrincipalResolver: SiriusPrincipalResolver = {
+  id: "community",
+  resolve: ({ session }: SiriusPrincipalResolutionInput) => {
+    const user = session?.user;
+
+    if (!user) {
+      return Promise.resolve(null);
+    }
+
+    return Promise.resolve({
+      subjectId: user.id ?? "",
+      displayName: user.name ?? null,
+      capabilities: COMMUNITY_CAPABILITIES,
+    });
+  },
+};
+
+/**
+ * Resolves the calling principal, failing closed.
+ *
+ * A resolver that throws yields no principal rather than falling back to
+ * another edition's capability set, so an unreachable identity or entitlement
+ * service denies gated work instead of granting it.
+ */
+export async function resolvePrincipal(
+  resolver: SiriusPrincipalResolver,
+  input: SiriusPrincipalResolutionInput,
+): Promise<SiriusPrincipal | null> {
+  try {
+    return await resolver.resolve(input);
+  } catch (cause) {
+    console.error(
+      `Capability principal resolver ${resolver.id} failed; denying capabilities`,
+      cause,
+    );
+    return null;
+  }
+}
+
+/**
+ * Throws a `SiriusCapabilityError` unless the principal holds every required
+ * capability. An empty requirement list is always satisfied.
+ */
+export function assertPrincipalCapabilities(
+  principal: SiriusPrincipal | null,
+  requiredCapabilities: readonly SiriusCapability[] = [],
+): void {
+  const missing = missingCapabilities(principal, requiredCapabilities);
+
+  if (missing.length > 0) {
+    throw new SiriusCapabilityError(missing);
+  }
+}
+
+/**
+ * Applies session enrichers in registry order. An enricher that throws is
+ * skipped so a failing extension cannot break authentication for the base
+ * session.
+ */
+export async function applySessionEnrichers(
+  enrichers: readonly SiriusSessionEnricher[],
+  session: Session,
+  principal: SiriusPrincipal | null,
+): Promise<Session> {
+  let enriched = session;
+
+  for (const enricher of enrichers) {
+    try {
+      enriched = await enricher.enrich(enriched, principal);
+    } catch (cause) {
+      console.error(`Session enricher ${enricher.id} failed`, cause);
+    }
+  }
+
+  return enriched;
+}

--- a/sirius-ui/src/server/extensions/registered-routers.ts
+++ b/sirius-ui/src/server/extensions/registered-routers.ts
@@ -1,0 +1,15 @@
+/**
+ * Build-time tRPC router slot.
+ *
+ * Community intentionally keeps this empty. A private build overlays this module
+ * with its routers so `root.ts` can spread them into the application router;
+ * because they are an object literal, tRPC keeps inferring client types for the
+ * contributed namespaces.
+ *
+ * This lives apart from `registered.ts` on purpose. Router modules import
+ * `createTRPCRouter`/`protectedProcedure` from `~/server/api/trpc`, which itself
+ * imports the extension registry to enforce capabilities. Declarations and
+ * routers therefore cannot share a module: only `root.ts` imports this one, so
+ * the router modules load after `trpc.ts` has finished initializing.
+ */
+export const registeredServerRouters = {};

--- a/sirius-ui/src/server/extensions/registered.ts
+++ b/sirius-ui/src/server/extensions/registered.ts
@@ -1,0 +1,24 @@
+import type { SiriusServerExtension } from "./types";
+
+/**
+ * Build-time server extension slot.
+ *
+ * Community intentionally keeps both exports empty. A private build overlays
+ * this module so it can add tRPC namespaces, a principal resolver, and session
+ * enrichment without editing the canonical registry, `root.ts`, `trpc.ts`, or
+ * `auth.ts`.
+ *
+ * The two exports are deliberately separate:
+ *
+ * - `registeredServerExtensions` carries the runtime declarations the registry
+ *   validates and enforces.
+ * - `registeredServerRouters` carries the routers themselves as an object
+ *   literal, so spreading it into the application router preserves tRPC's
+ *   client-side type inference.
+ *
+ * `root.ts` cross-checks the two, so an overlay that adds a router without
+ * declaring its namespace (or the reverse) fails at startup.
+ */
+export const registeredServerExtensions: readonly SiriusServerExtension[] = [];
+
+export const registeredServerRouters = {};

--- a/sirius-ui/src/server/extensions/registered.ts
+++ b/sirius-ui/src/server/extensions/registered.ts
@@ -3,22 +3,18 @@ import type { SiriusServerExtension } from "./types";
 /**
  * Build-time server extension slot.
  *
- * Community intentionally keeps both exports empty. A private build overlays
- * this module so it can add tRPC namespaces, a principal resolver, and session
+ * Community intentionally keeps this empty. A private build overlays this module
+ * so it can declare tRPC namespaces, a principal resolver, and session
  * enrichment without editing the canonical registry, `root.ts`, `trpc.ts`, or
  * `auth.ts`.
  *
- * The two exports are deliberately separate:
+ * These are declarations only. The routers themselves are contributed through
+ * `registered-routers.ts`, and `root.ts` cross-checks the two, so an overlay that
+ * adds a router without declaring its namespace (or the reverse) fails at
+ * startup.
  *
- * - `registeredServerExtensions` carries the runtime declarations the registry
- *   validates and enforces.
- * - `registeredServerRouters` carries the routers themselves as an object
- *   literal, so spreading it into the application router preserves tRPC's
- *   client-side type inference.
- *
- * `root.ts` cross-checks the two, so an overlay that adds a router without
- * declaring its namespace (or the reverse) fails at startup.
+ * A module reachable from here must not import `~/server/api/trpc`: `trpc.ts`
+ * imports this registry to enforce capabilities, so doing so would form an
+ * import cycle. Keep router construction in `registered-routers.ts`.
  */
 export const registeredServerExtensions: readonly SiriusServerExtension[] = [];
-
-export const registeredServerRouters = {};

--- a/sirius-ui/src/server/extensions/registry.test.ts
+++ b/sirius-ui/src/server/extensions/registry.test.ts
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import type { Session } from "next-auth";
+import { COMMUNITY_CAPABILITIES } from "~/contracts/capabilities";
+import { communityServerExtension } from "./community";
+import {
+  SiriusCapabilityError,
+  applySessionEnrichers,
+  assertPrincipalCapabilities,
+  communityPrincipalResolver,
+  resolvePrincipal,
+} from "./principal";
+import { createServerExtensionRegistry } from "./registry";
+import type { SiriusPrincipalResolver, SiriusServerExtension } from "./types";
+
+function sessionFor(user: Session["user"] | undefined): Session {
+  return { expires: "2099-01-01T00:00:00.000Z", user } as Session;
+}
+
+async function silenceErrors<T>(run: () => Promise<T>): Promise<T> {
+  const original = console.error;
+  console.error = () => undefined;
+
+  try {
+    return await run();
+  } finally {
+    console.error = original;
+  }
+}
+
+const reporting: SiriusServerExtension = {
+  id: "reporting.server",
+  version: "1.0.0",
+  routerNamespaces: [
+    { namespace: "reports", requiredCapabilities: ["reporting.enterprise"] },
+  ],
+};
+
+const registry = createServerExtensionRegistry([
+  reporting,
+  communityServerExtension,
+]);
+
+// Community sorts first because it declares an explicit order.
+assert.deepEqual(
+  registry.extensions.map((extension) => extension.id),
+  ["community.server", "reporting.server"],
+);
+
+assert.deepEqual(registry.getRequiredCapabilitiesForNamespace("host"), [
+  "api.hosts",
+]);
+assert.deepEqual(
+  registry.getRequiredCapabilitiesForProcedure("host.getAllHosts"),
+  ["api.hosts"],
+);
+assert.deepEqual(registry.getRequiredCapabilitiesForProcedure("reports.list"), [
+  "reporting.enterprise",
+]);
+assert.deepEqual(registry.getRequiredCapabilitiesForProcedure("unknown.x"), []);
+assert.equal(registry.principalResolver.id, "community");
+assert.deepEqual(registry.sessionEnrichers, []);
+
+// Every namespace Community declares must be reachable by the Community
+// principal, otherwise the deployment would deny its own procedures.
+for (const namespace of communityServerExtension.routerNamespaces ?? []) {
+  for (const capability of namespace.requiredCapabilities ?? []) {
+    assert.ok(
+      COMMUNITY_CAPABILITIES.includes(capability),
+      `Community namespace ${namespace.namespace} requires unknown capability ${capability}`,
+    );
+  }
+}
+
+assert.throws(
+  () =>
+    createServerExtensionRegistry([
+      communityServerExtension,
+      { ...reporting, id: "community.server" },
+    ]),
+  /Duplicate server extension id: community\.server/,
+);
+
+assert.throws(
+  () =>
+    createServerExtensionRegistry([
+      communityServerExtension,
+      {
+        ...reporting,
+        routerNamespaces: [{ namespace: "host" }],
+      },
+    ]),
+  /Duplicate router namespace: host/,
+);
+
+assert.throws(
+  () =>
+    createServerExtensionRegistry([
+      communityServerExtension,
+      {
+        ...reporting,
+        principalResolver: {
+          id: "reporting",
+          resolve: () => Promise.resolve(null),
+        },
+      },
+    ]),
+  /Only one principal resolver may be registered in a build/,
+);
+
+assert.throws(
+  () =>
+    createServerExtensionRegistry([
+      {
+        ...reporting,
+        sessionEnrichers: [
+          { id: "shared", enrich: (session) => session },
+          { id: "shared", enrich: (session) => session },
+        ],
+      },
+    ]),
+  /Duplicate session enricher id: shared/,
+);
+
+// The composed application router and the declared namespaces must agree.
+const declaredNamespaces = registry.routerNamespaces.map(
+  (entry) => entry.namespace,
+);
+registry.assertRouterNamespaces(declaredNamespaces);
+assert.throws(
+  () => registry.assertRouterNamespaces([...declaredNamespaces, "undeclared"]),
+  /Router namespace undeclared is not declared by any server extension/,
+);
+assert.throws(
+  () => registry.assertRouterNamespaces(declaredNamespaces.slice(1)),
+  /Declared router namespace .* is missing from the application router/,
+);
+
+// An extension may register its own resolver, and it becomes authoritative.
+const overlayResolver: SiriusPrincipalResolver = {
+  id: "overlay",
+  resolve: () =>
+    Promise.resolve({
+      subjectId: "subject-1",
+      displayName: "Subject One",
+      capabilities: ["reporting.enterprise"],
+    }),
+};
+assert.equal(
+  createServerExtensionRegistry([
+    { ...reporting, principalResolver: overlayResolver },
+  ]).principalResolver.id,
+  "overlay",
+);
+
+async function assertCommunityResolverBehavior(): Promise<void> {
+  assert.equal(
+    await communityPrincipalResolver.resolve({ session: null }),
+    null,
+    "an unauthenticated request must not resolve a principal",
+  );
+  assert.equal(
+    await communityPrincipalResolver.resolve({
+      session: sessionFor(undefined),
+    }),
+    null,
+    "a session without a user must not resolve a principal",
+  );
+
+  const principal = await communityPrincipalResolver.resolve({
+    session: sessionFor({ id: "1", name: "admin", email: "admin@sirius.local" }),
+  });
+  assert.equal(principal?.subjectId, "1");
+  assert.deepEqual(principal?.capabilities, COMMUNITY_CAPABILITIES);
+}
+
+async function assertPrincipalResolutionFailsClosed(): Promise<void> {
+  const failingResolver: SiriusPrincipalResolver = {
+    id: "failing",
+    resolve: () => Promise.reject(new Error("entitlement service unreachable")),
+  };
+
+  const principal = await silenceErrors(() =>
+    resolvePrincipal(failingResolver, {
+      session: sessionFor({ id: "1", name: "admin", email: "a@b.c" }),
+    }),
+  );
+
+  assert.equal(
+    principal,
+    null,
+    "a failing resolver must not inherit another edition's capabilities",
+  );
+  assert.throws(
+    () => assertPrincipalCapabilities(principal, ["api.hosts"]),
+    (error: unknown) =>
+      error instanceof SiriusCapabilityError &&
+      error.code === "CAPABILITY_REQUIRED" &&
+      error.missing.length === 1 &&
+      error.missing[0] === "api.hosts",
+  );
+  assert.doesNotThrow(() => assertPrincipalCapabilities(principal, []));
+}
+
+async function assertCommunityPrincipalCannotReachOverlayNamespace(): Promise<void> {
+  const principal = await communityPrincipalResolver.resolve({
+    session: sessionFor({ id: "1", name: "admin", email: "a@b.c" }),
+  });
+
+  assert.doesNotThrow(() =>
+    assertPrincipalCapabilities(
+      principal,
+      registry.getRequiredCapabilitiesForProcedure("host.getAllHosts"),
+    ),
+  );
+  assert.throws(
+    () =>
+      assertPrincipalCapabilities(
+        principal,
+        registry.getRequiredCapabilitiesForProcedure("reports.list"),
+      ),
+    SiriusCapabilityError,
+  );
+}
+
+async function assertSessionEnrichmentIsIsolated(): Promise<void> {
+  const session = sessionFor({ id: "1", name: "admin", email: "a@b.c" });
+  const enriched = await silenceErrors(() =>
+    applySessionEnrichers(
+      [
+        {
+          id: "failing",
+          enrich: () => {
+            throw new Error("enricher exploded");
+          },
+        },
+        {
+          id: "tagging",
+          enrich: (current, principal) => ({
+            ...current,
+            user: { ...current.user, name: principal?.displayName ?? "" },
+          }),
+        },
+      ],
+      session,
+      { subjectId: "1", displayName: "Enriched", capabilities: [] },
+    ),
+  );
+
+  assert.equal(
+    enriched.user.name,
+    "Enriched",
+    "a failing enricher must not stop later enrichers",
+  );
+  assert.equal(session.user.name, "admin", "enrichment must not mutate input");
+}
+
+async function runAsyncAssertions(): Promise<void> {
+  await assertCommunityResolverBehavior();
+  await assertPrincipalResolutionFailsClosed();
+  await assertCommunityPrincipalCannotReachOverlayNamespace();
+  await assertSessionEnrichmentIsIsolated();
+}
+
+runAsyncAssertions()
+  .then(() => {
+    console.log("Server extension contract tests passed");
+  })
+  .catch((cause: unknown) => {
+    console.error(cause);
+    process.exit(1);
+  });

--- a/sirius-ui/src/server/extensions/registry.test.ts
+++ b/sirius-ui/src/server/extensions/registry.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import type { Session } from "next-auth";
 import { COMMUNITY_CAPABILITIES } from "~/contracts/capabilities";
 import { communityServerExtension } from "./community";
@@ -25,6 +27,26 @@ async function silenceErrors<T>(run: () => Promise<T>): Promise<T> {
   } finally {
     console.error = original;
   }
+}
+
+// `trpc.ts` imports this registry to enforce capabilities, so a declaration
+// module that imports `trpc.ts` back forms a cycle: the overlay's routers then
+// fail at load with "Cannot access 'createTRPCRouter' before initialization".
+// Routers belong in `registered-routers.ts`, which only `root.ts` imports.
+for (const declarationModule of [
+  "index.ts",
+  "registered.ts",
+  "registry.ts",
+  "principal.ts",
+  "community.ts",
+  "types.ts",
+]) {
+  const source = readFileSync(path.join(__dirname, declarationModule), "utf8");
+  assert.doesNotMatch(
+    source,
+    /from\s+"~\/server\/api\/trpc"/,
+    `${declarationModule} must not import the tRPC root; it would cycle through the registry`,
+  );
 }
 
 const reporting: SiriusServerExtension = {

--- a/sirius-ui/src/server/extensions/registry.test.ts
+++ b/sirius-ui/src/server/extensions/registry.test.ts
@@ -95,11 +95,18 @@ assert.throws(
 assert.throws(
   () =>
     createServerExtensionRegistry([
-      communityServerExtension,
       {
         ...reporting,
         principalResolver: {
           id: "reporting",
+          resolve: () => Promise.resolve(null),
+        },
+      },
+      {
+        id: "identity.server",
+        version: "1.0.0",
+        principalResolver: {
+          id: "identity",
           resolve: () => Promise.resolve(null),
         },
       },
@@ -135,7 +142,8 @@ assert.throws(
   /Declared router namespace .* is missing from the application router/,
 );
 
-// An extension may register its own resolver, and it becomes authoritative.
+// A build-selected resolver replaces the Community fallback while Community
+// namespace declarations remain present. This is the actual Pro composition.
 const overlayResolver: SiriusPrincipalResolver = {
   id: "overlay",
   resolve: () =>
@@ -145,11 +153,18 @@ const overlayResolver: SiriusPrincipalResolver = {
       capabilities: ["reporting.enterprise"],
     }),
 };
-assert.equal(
-  createServerExtensionRegistry([
-    { ...reporting, principalResolver: overlayResolver },
-  ]).principalResolver.id,
-  "overlay",
+const overlayRegistry = createServerExtensionRegistry([
+  communityServerExtension,
+  { ...reporting, principalResolver: overlayResolver },
+]);
+assert.equal(overlayRegistry.principalResolver.id, "overlay");
+assert.deepEqual(
+  overlayRegistry.getRequiredCapabilitiesForProcedure("host.getAllHosts"),
+  ["api.hosts"],
+);
+assert.deepEqual(
+  overlayRegistry.getRequiredCapabilitiesForProcedure("reports.list"),
+  ["reporting.enterprise"],
 );
 
 async function assertCommunityResolverBehavior(): Promise<void> {

--- a/sirius-ui/src/server/extensions/registry.ts
+++ b/sirius-ui/src/server/extensions/registry.ts
@@ -1,0 +1,146 @@
+import type { SiriusCapability } from "~/contracts/capabilities";
+import { communityPrincipalResolver } from "./principal";
+import type {
+  SiriusPrincipalResolver,
+  SiriusServerExtension,
+  SiriusServerRouterNamespace,
+  SiriusSessionEnricher,
+} from "./types";
+
+export interface SiriusServerExtensionRegistry {
+  readonly extensions: readonly SiriusServerExtension[];
+  readonly routerNamespaces: readonly SiriusServerRouterNamespace[];
+  readonly principalResolver: SiriusPrincipalResolver;
+  readonly sessionEnrichers: readonly SiriusSessionEnricher[];
+  getRequiredCapabilitiesForNamespace: (
+    namespace: string,
+  ) => readonly SiriusCapability[];
+  getRequiredCapabilitiesForProcedure: (
+    path: string,
+  ) => readonly SiriusCapability[];
+  assertRouterNamespaces: (namespaces: readonly string[]) => void;
+}
+
+const DEFAULT_EXTENSION_ORDER = 1000;
+
+function compareExtensions(
+  left: SiriusServerExtension,
+  right: SiriusServerExtension,
+): number {
+  const orderDifference =
+    (left.order ?? DEFAULT_EXTENSION_ORDER) -
+    (right.order ?? DEFAULT_EXTENSION_ORDER);
+  return orderDifference === 0
+    ? left.id.localeCompare(right.id)
+    : orderDifference;
+}
+
+function requireNonEmpty(value: string, label: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`${label} must not be empty`);
+  }
+}
+
+function assertUniqueIDs(
+  contributions: readonly { id: string }[],
+  label: string,
+): void {
+  const seen = new Set<string>();
+  for (const contribution of contributions) {
+    requireNonEmpty(contribution.id, `${label} id`);
+    if (seen.has(contribution.id)) {
+      throw new Error(`Duplicate ${label} id: ${contribution.id}`);
+    }
+    seen.add(contribution.id);
+  }
+}
+
+function assertUniqueNamespaces(
+  namespaces: readonly SiriusServerRouterNamespace[],
+): void {
+  const seen = new Set<string>();
+  for (const entry of namespaces) {
+    requireNonEmpty(entry.namespace, "Router namespace");
+    if (seen.has(entry.namespace)) {
+      throw new Error(`Duplicate router namespace: ${entry.namespace}`);
+    }
+    seen.add(entry.namespace);
+  }
+}
+
+/**
+ * Build the immutable compile-time server registry.
+ *
+ * The caller supplies Community plus any build-selected contributions.
+ * Validation happens before the registry is exposed so a conflicting overlay
+ * fails during build/startup rather than serving ambiguous procedures or
+ * ambiguous authorization at runtime.
+ */
+export function createServerExtensionRegistry(
+  extensions: readonly SiriusServerExtension[],
+): SiriusServerExtensionRegistry {
+  const orderedExtensions = [...extensions].sort(compareExtensions);
+  assertUniqueIDs(orderedExtensions, "server extension");
+
+  const routerNamespaces = orderedExtensions.flatMap(
+    (extension) => extension.routerNamespaces ?? [],
+  );
+  assertUniqueNamespaces(routerNamespaces);
+
+  const sessionEnrichers = orderedExtensions.flatMap(
+    (extension) => extension.sessionEnrichers ?? [],
+  );
+  assertUniqueIDs(sessionEnrichers, "session enricher");
+
+  const principalResolvers = orderedExtensions
+    .map((extension) => extension.principalResolver)
+    .filter(
+      (resolver): resolver is SiriusPrincipalResolver => resolver !== undefined,
+    );
+
+  if (principalResolvers.length > 1) {
+    throw new Error(
+      "Only one principal resolver may be registered in a build",
+    );
+  }
+
+  const capabilitiesByNamespace = new Map<string, readonly SiriusCapability[]>(
+    routerNamespaces.map((entry) => [
+      entry.namespace,
+      entry.requiredCapabilities ?? [],
+    ]),
+  );
+
+  const registry: SiriusServerExtensionRegistry = {
+    extensions: Object.freeze([...orderedExtensions]),
+    routerNamespaces: Object.freeze([...routerNamespaces]),
+    principalResolver: principalResolvers[0] ?? communityPrincipalResolver,
+    sessionEnrichers: Object.freeze([...sessionEnrichers]),
+    getRequiredCapabilitiesForNamespace: (namespace) =>
+      capabilitiesByNamespace.get(namespace) ?? [],
+    getRequiredCapabilitiesForProcedure: (path) =>
+      registry.getRequiredCapabilitiesForNamespace(path.split(".")[0] ?? ""),
+    assertRouterNamespaces: (namespaces) => {
+      const declared = new Set(capabilitiesByNamespace.keys());
+
+      for (const namespace of namespaces) {
+        if (!declared.has(namespace)) {
+          throw new Error(
+            `Router namespace ${namespace} is not declared by any server extension`,
+          );
+        }
+      }
+
+      const composed = new Set(namespaces);
+      for (const namespace of declared) {
+        if (!composed.has(namespace)) {
+          throw new Error(
+            `Declared router namespace ${namespace} is missing from the application router`,
+          );
+        }
+      }
+    },
+  };
+
+  return Object.freeze(registry);
+}

--- a/sirius-ui/src/server/extensions/types.ts
+++ b/sirius-ui/src/server/extensions/types.ts
@@ -1,0 +1,65 @@
+import type { Session } from "next-auth";
+import type { SiriusCapability, SiriusPrincipal } from "~/contracts/capabilities";
+
+/**
+ * A tRPC namespace claimed by an extension.
+ *
+ * The namespace is the top-level key under which the contribution's router is
+ * merged into the application router, which is also the first path segment of
+ * every procedure it serves (`host.getHosts` belongs to namespace `host`).
+ * Declaring the namespace here lets Core enforce the contribution's capability
+ * requirements without knowing anything about the router itself.
+ */
+export interface SiriusServerRouterNamespace {
+  namespace: string;
+  requiredCapabilities?: readonly SiriusCapability[];
+}
+
+export interface SiriusPrincipalResolutionInput {
+  session: Session | null;
+}
+
+/**
+ * Establishes the calling subject and its capabilities.
+ *
+ * Community resolves an authenticated session to the static Community
+ * capability catalog. A private build may resolve the same session against its
+ * own identity and authorization policy. Returning `null` means no principal
+ * could be established, which denies every gated procedure.
+ */
+export interface SiriusPrincipalResolver {
+  id: string;
+  resolve: (
+    input: SiriusPrincipalResolutionInput,
+  ) => Promise<SiriusPrincipal | null>;
+}
+
+/**
+ * Adds edition-specific data to the session NextAuth returns to the browser.
+ *
+ * Community contributes no enricher. The hook exists so a private build can
+ * publish its own principal data without forking `auth.ts`.
+ */
+export interface SiriusSessionEnricher {
+  id: string;
+  enrich: (
+    session: Session,
+    principal: SiriusPrincipal | null,
+  ) => Session | Promise<Session>;
+}
+
+/**
+ * A compile-time server extension contribution.
+ *
+ * This mirrors `SiriusUIExtension` on the browser side: Community registers its
+ * own declarations and a private build overlays `registered.ts`. The registry is
+ * assembled during module evaluation; no runtime plugin loading is involved.
+ */
+export interface SiriusServerExtension {
+  id: string;
+  version: string;
+  order?: number;
+  routerNamespaces?: readonly SiriusServerRouterNamespace[];
+  principalResolver?: SiriusPrincipalResolver;
+  sessionEnrichers?: readonly SiriusSessionEnricher[];
+}

--- a/sirius-ui/src/ui/extensions/capabilities.tsx
+++ b/sirius-ui/src/ui/extensions/capabilities.tsx
@@ -6,6 +6,11 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import {
+  communityCapabilitySnapshot,
+  communityPrincipal,
+  hasRequiredCapabilities,
+} from "~/contracts/capabilities";
 import type {
   SiriusCapability,
   SiriusCapabilityProviderDefinition,
@@ -13,69 +18,20 @@ import type {
   SiriusPrincipal,
 } from "./types";
 
-/**
- * Community capabilities are available without a license or entitlement
- * service. Keep this list aligned with the public edition-boundary catalog.
- */
-export const COMMUNITY_CAPABILITIES: readonly SiriusCapability[] = [
-  "scanning.core",
-  "inventory.hosts",
-  "findings.vulnerabilities",
-  "api.public_rest",
-  "ui.dashboard_shell",
-  "auth.local_users",
-  "auth.api_keys",
-  "messaging.queues",
-  "storage.postgres_core",
-  "storage.valkey",
-  "migrations.core",
-  "extensions.module_registry",
-  "ui.scanner",
-  "ui.vulnerabilities",
-  "ui.environment",
-  "ui.terminal",
-  "api.hosts",
-  "api.vulnerabilities",
-  "api.templates",
-  "api.agent_templates",
-  "api.events",
-  "api.snapshots",
-  "api.statistics",
-  "api.scan_control",
-  "engine.scanner",
-  "engine.agent_runtime",
-  "agents.remote",
-  "reporting.basic_export",
-];
-
-export const communityPrincipal: SiriusPrincipal = {
-  subjectId: "community",
-  displayName: "Community",
-  capabilities: COMMUNITY_CAPABILITIES,
-};
-
-export const communityCapabilitySnapshot: SiriusCapabilitySnapshot = {
-  principal: communityPrincipal,
-  source: "community",
-};
+export {
+  COMMUNITY_CAPABILITIES,
+  anonymousPrincipal,
+  communityCapabilitySnapshot,
+  communityPrincipal,
+  hasRequiredCapabilities,
+  missingCapabilities,
+} from "~/contracts/capabilities";
 
 export const communityCapabilityProvider: SiriusCapabilityProviderDefinition = {
   id: "community",
   initialSnapshot: communityCapabilitySnapshot,
   load: () => Promise.resolve(communityCapabilitySnapshot),
 };
-
-export function hasRequiredCapabilities(
-  availableCapabilities: readonly SiriusCapability[],
-  requiredCapabilities: readonly SiriusCapability[] = [],
-): boolean {
-  if (requiredCapabilities.length === 0) {
-    return true;
-  }
-
-  const available = new Set(availableCapabilities);
-  return requiredCapabilities.every((capability) => available.has(capability));
-}
 
 export interface CapabilityLoadResult {
   snapshot: SiriusCapabilitySnapshot;

--- a/sirius-ui/src/ui/extensions/types.ts
+++ b/sirius-ui/src/ui/extensions/types.ts
@@ -1,23 +1,20 @@
 import type React from "react";
+import type {
+  SiriusCapability,
+  SiriusCapabilityProviderDefinition,
+} from "~/contracts/capabilities";
 
-export type SiriusCapability = string;
-
-export interface SiriusPrincipal {
-  subjectId: string;
-  displayName?: string | null;
-  capabilities: readonly SiriusCapability[];
-}
-
-export interface SiriusCapabilitySnapshot {
-  principal: SiriusPrincipal;
-  source: string;
-}
-
-export interface SiriusCapabilityProviderDefinition {
-  id: string;
-  initialSnapshot: SiriusCapabilitySnapshot;
-  load?: () => Promise<SiriusCapabilitySnapshot>;
-}
+/**
+ * The neutral capability/principal primitives are shared with the server
+ * registry, so they live in `~/contracts/capabilities` and are re-exported here
+ * for consumers of the UI extension contract.
+ */
+export type {
+  SiriusCapability,
+  SiriusCapabilityProviderDefinition,
+  SiriusCapabilitySnapshot,
+  SiriusPrincipal,
+} from "~/contracts/capabilities";
 
 export interface SiriusNavigationIconProps {
   className?: string;

--- a/tasks/pro-bifurcation.json
+++ b/tasks/pro-bifurcation.json
@@ -202,6 +202,16 @@
         "testStrategy": "Community UI renders identical navigation and pages from the registry (visual/E2E regression); a test extension adds a nav item and page gated by a fake capability."
       },
       {
+        "id": "3.7",
+        "title": "Server principal resolver and tRPC extension seam",
+        "description": "Build-time SiriusServerExtension registry in sirius-ui: neutral principal resolution, capability-enforcing tRPC procedures, namespace overlay, and session enrichment hooks.",
+        "details": "Completes the server half of the UI/auth extension seam (Sirius #147) that task 3.4 left open. Neutral capability/principal primitives moved to src/contracts/capabilities.ts so the browser registry and the server registry share one catalog, pinned by test to documentation/product/edition-boundary.yaml. src/server/extensions/ declares tRPC namespaces with requiredCapabilities, at most one principal resolver, and optional session enrichers; registered.ts is the private build overlay and root.ts cross-checks declared namespaces against composed routers. protectedProcedure now enforces the namespace capabilities, and principal resolution fails closed when a resolver throws. Community resolves any authenticated session to the static Community catalog, so Community behavior is unchanged. Entitlement/licensing enforcement remains Phase 4.",
+        "status": "done",
+        "priority": "high",
+        "dependencies": ["3.4"],
+        "testStrategy": "Contract tests cover registry ordering, duplicate extension/namespace/enricher rejection, single-resolver enforcement, namespace/router drift in both directions, fail-closed principal resolution, and enricher isolation; an in-process caller proves a community principal reaches a declared namespace while an unresolved principal is denied."
+      },
+      {
         "id": "3.5",
         "title": "Engine enrichment and scoring interfaces",
         "description": "ResultEnricher, RiskScorer, and scheduling-policy interfaces in go-api with deterministic ordering and health reporting.",
@@ -218,7 +228,7 @@
         "details": "Golden contract fixtures + versioned schema diffing runnable from both public CI and (later) the Pro pipeline. Tag a core release (v1.2.0) containing all contracts.",
         "status": "pending",
         "priority": "high",
-        "dependencies": ["3.1", "3.3", "3.4", "3.5"],
+        "dependencies": ["3.1", "3.3", "3.4", "3.5", "3.7"],
         "testStrategy": "Harness fails on a synthetic breaking change and passes on an additive change; v1.2.0 released with contracts documented."
       }
     ]


### PR DESCRIPTION
## Summary

Completes the remaining server-side portion of **#147** by adding public, policy-neutral auth/principal and tRPC extension seams that private distributions can consume without patching Core `auth.ts`, `trpc.ts`, or `root.ts`.

This PR keeps Community behavior unchanged with zero private extensions while making server authorization authoritative and build-time extension composition explicit.

Closes #147

## What changed

### Shared neutral capability/principal contracts

Moves shared primitives into React-free `src/contracts/capabilities.ts` so browser gating and server enforcement consume one catalog and one principal model.

- `SiriusCapability`
- `SiriusPrincipal`
- capability snapshots/provider types
- Community capability catalog
- anonymous/fail-closed principal
- shared capability helpers

The Community capability catalog is pinned by contract test to `documentation/product/edition-boundary.yaml`.

### Server extension registry

Adds a deterministic build-time registry under `src/server/extensions/` for:

- tRPC namespace declarations and required capabilities;
- at most one authoritative principal resolver;
- ordered session enrichers;
- namespace collision validation;
- composed-router/declaration cross-checks.

Community declares its router namespaces but does **not** register a principal resolver contribution. The registry falls back to the Community resolver when no extension supplies one, allowing exactly one build-selected/private resolver to become authoritative while preserving zero-extension Community behavior.

### Authoritative tRPC authorization

`tRPC` context now resolves a neutral principal through the registered resolver. `protectedProcedure` enforces the capability requirements declared for the procedure's top-level namespace.

An extension can therefore contribute a private namespace and its capability requirement without patching Core procedures.

Resolver failures fail closed: no principal is resolved, and gated procedures are denied.

### Router composition seam

`registered.ts` exposes two deliberately separate build-time extension values:

- declarations for validation/enforcement;
- router object-literal contributions for preserving tRPC `AppRouter` type inference.

`root.ts` cross-checks declarations and composed router namespaces in both directions so undeclared or missing extension namespaces fail at startup.

### Session enrichment seam

NextAuth session construction can apply ordered extension enrichers without embedding roles or private identity policy in Core. Authoritative authorization remains server principal/capability based; client session enrichment is not an authorization source.

### CI contract enforcement

Adds blocking `npm run test:extensions` to the UI CI job. This runs:

- capability catalog/source-of-truth tests;
- browser extension registry tests;
- server extension/auth tests.

## Architectural invariants

- Community remains fully functional with zero registered private extensions.
- Core contracts contain no `admin`, `member`, `student`, workspace, entitlement, or Pro-role policy.
- `CapabilityGate` remains presentation gating; server principal enforcement is authoritative.
- A principal resolver failure cannot inherit Community capabilities.
- Exactly one build-selected resolver may be authoritative.
- Community is the fallback resolver only when no extension resolver is registered.
- Private routers cannot silently shadow Community namespaces.
- Every composed router namespace must have an explicit capability declaration and vice versa.
- No runtime plugin loading is introduced.

## Tests

The contract tests cover:

- Community catalog drift from edition-boundary documentation;
- zero-extension Community resolver behavior;
- private resolver replacing the Community fallback while Community namespaces remain registered;
- rejection of two contributed resolvers;
- duplicate server-extension IDs;
- duplicate router namespaces;
- duplicate session-enricher IDs;
- composed/declaration namespace mismatches;
- fail-closed principal resolution;
- Community principal denial from a private capability namespace;
- isolated session-enricher failures.

## Validation reported by implementation team

- capability, UI-extension, and server-extension test suites pass;
- in-process tRPC caller confirmed Community access to declared Core namespace and `FORBIDDEN` on unresolved principal;
- runtime `root.ts` composition confirmed 17 composed namespaces against 17 declarations;
- branch and `main` both report the same 98 baseline `tsc --noEmit` diagnostics;
- `auth.ts` has the same 10 pre-existing lint diagnostics on branch and `main`.

## Review focus

Please review especially:

1. whether the principal resolver replacement model is sufficiently narrow and deterministic;
2. whether namespace-level capability enforcement is an appropriate default for Core routers;
3. whether router object-literal composition preserves tRPC client inference;
4. whether session enrichment remains clearly non-authoritative;
5. failure semantics and startup collision behavior;
6. whether future Pro identity work can consume this seam without copying Core auth/router files.

This is the server-side counterpart to the UI extension work merged in #149/#150 and is a foundation dependency for the private multi-user identity vertical.